### PR TITLE
Apply card-based redesign to sampling views

### DIFF
--- a/AIS/AIS/Views/Sampling/Account_exception.cshtml
+++ b/AIS/AIS/Views/Sampling/Account_exception.cshtml
@@ -64,29 +64,34 @@
     }    
 
 </script>
-
-<div class="row col-md-12 mt-3">
-    <h3 style="color: #45c545;">Accounts Report</h3>
-
-</div>
-<div class="row col-md-12 mt-3">
-    <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Account No</th>
-                <th>Account Title</th>
-                <th>Customer Name</th>
-                <th>master code</th>
-                <th>Details</th>
-                <th>transaction Date</th>
-                <th>Authorization Date</th>
-                <th>DR Amount</th>
-                <th>CR Amount</th>
-                <th></th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Accounts Report</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Sr No</th>
+                            <th>Account No</th>
+                            <th>Account Title</th>
+                            <th>Customer Name</th>
+                            <th>master code</th>
+                            <th>Details</th>
+                            <th>transaction Date</th>
+                            <th>Authorization Date</th>
+                            <th>DR Amount</th>
+                            <th>CR Amount</th>
+                            <th></th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>

--- a/AIS/AIS/Views/Sampling/Account_exception_details.cshtml
+++ b/AIS/AIS/Views/Sampling/Account_exception_details.cshtml
@@ -66,29 +66,34 @@
     }    
 
 </script>
-
-<div class="row col-md-12 mt-3">
-    <h3 style="color: #45c545;">Accounts Report</h3>
-
-</div>
-<div class="row col-md-12 mt-3">
-    <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Account No</th>
-                <th>Account Title</th>
-                <th>Customer Name</th>
-                <th>DOB</th>
-                <th>Cell</th>
-                <th>CNIC</th>
-                <th>CNIC Expiry</th>
-                <th>Account Type</th>
-                <th>Account Category</th>
-                <th></th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Accounts Report</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Sr No</th>
+                            <th>Account No</th>
+                            <th>Account Title</th>
+                            <th>Customer Name</th>
+                            <th>DOB</th>
+                            <th>Cell</th>
+                            <th>CNIC</th>
+                            <th>CNIC Expiry</th>
+                            <th>Account Type</th>
+                            <th>Account Category</th>
+                            <th></th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>

--- a/AIS/AIS/Views/Sampling/account_document.cshtml
+++ b/AIS/AIS/Views/Sampling/account_document.cshtml
@@ -4,6 +4,7 @@
 }
 <!-- Add reference to custom CSS -->
 <link rel="stylesheet" href="~/css/account_document.css" />
+<link rel="stylesheet" href="~/css/sampling.css" />
 
 <script type="text/javascript">
     var g_engId = 0;
@@ -92,7 +93,7 @@
 <div class="container-fluid mt-4">
     <div class="row justify-content-center">
         <div class="col-lg-10">
-            <div class="card shadow-sm border-0">
+            <div class="card card-sample shadow-sm">
                 <div class="card-header bg-success text-white d-flex align-items-center">
                     <i class="bi bi-folder2-open me-2"></i>
                     <h4 class="mb-0">Account Document List</h4>

--- a/AIS/AIS/Views/Sampling/account_transaction.cshtml
+++ b/AIS/AIS/Views/Sampling/account_transaction.cshtml
@@ -71,28 +71,31 @@
         return amount ? parseFloat(amount).toFixed(2) : "0.00";
     }
 </script>
-
-<div class="row col-md-12 mt-3">
-
-    <h3 style="color: #45c545;">List of Account Transactions</h3>
-</div>
-
-<div class="row col-md-12 mt-3">
-    <table id="account_transaction_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Transaction Code</th>
-                <th>Instrument No</th>
-                <th>Description</th>
-                <th>Transaction Date</th>
-                <th>Authorization Date</th>
-                <th>Debit Amount</th>
-                <th>Credit Amount</th>
-               
-                <th>Remarks</th>                
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">List of Account Transactions</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="account_transaction_list" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Sr No</th>
+                            <th>Transaction Code</th>
+                            <th>Instrument No</th>
+                            <th>Description</th>
+                            <th>Transaction Date</th>
+                            <th>Authorization Date</th>
+                            <th>Debit Amount</th>
+                            <th>Credit Amount</th>
+                            <th>Remarks</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>

--- a/AIS/AIS/Views/Sampling/account_transaction_master.cshtml
+++ b/AIS/AIS/Views/Sampling/account_transaction_master.cshtml
@@ -1,8 +1,8 @@
-﻿@{
-    ViewData["Title"] = "List of Samples";
+@{
+    ViewData["Title"] = "Account Transaction Master";
     Layout = "_Layout";
 }
-
+<link rel="stylesheet" href="~/css/sampling.css" />
 <script type="text/javascript">
     var g_engID = 0;
     $(document).ready(function () {
@@ -12,11 +12,10 @@
         loadBIOMETSamples();
     });
 
-
     function loadBIOMETSamples() {
-       destroyDatatable('biomet_sample_list');
+        destroyDatatable('biomet_sample_list');
         $.ajax({
-             url: g_asiBaseURL + "/ApiCalls/get_biomet_sampling_details",
+            url: g_asiBaseURL + "/ApiCalls/get_biomet_sampling_details",
             type: "POST",
             data: { ENG_ID: '1828' },
             success: function (data) {
@@ -29,10 +28,9 @@
             }
         });
     }
-        function populateTable(data) {
+    function populateTable(data) {
         var tableBody = $("#biomet_sample_list tbody");
-        tableBody.empty(); // Clear existing rows
-
+        tableBody.empty();
         $.each(data, function (index, item) {
             var row = `<tr>
                 <td>${index + 1}</td>
@@ -45,153 +43,48 @@
                 <td>${formatDate(item.cnicExpiry)}</td>
                 <td>${item.acType}</td>
                 <td>${item.acCat}</td>
-                <td>
-                    <a href="./account_document?acNo=${item.acNo}" class="btn btn-primary btn-sm">Documents</a>
-                </td>
-                <td>
-                    <a href="./account_transaction?acNo=${item.acNo}" class="btn btn-success btn-sm">Transactions</a>
-                </td>
-                <td>
-                    <a href="./account_transaction_master?acNo=${item.acNo}" class="btn btn-warning btn-sm">Master</a>
-                </td>
+                <td><a href="./account_document?acNo=${item.acNo}" class="btn btn-primary btn-sm">Documents</a></td>
+                <td><a href="./account_transaction?acNo=${item.acNo}" class="btn btn-success btn-sm">Transactions</a></td>
+                <td><a href="./account_transaction_master?acNo=${item.acNo}" class="btn btn-warning btn-sm">Master</a></td>
             </tr>`;
             tableBody.append(row);
         });
-
         initializeDataTable('biomet_sample_list');
     }
-        function formatDate(dateString) {
+    function formatDate(dateString) {
         if (!dateString || dateString.trim() === "") return "";
         let date = new Date(dateString);
-        return date.toLocaleDateString(); // Adjust format as needed
+        return date.toLocaleDateString();
     }
-
-
-
 </script>
-
-<div class="row col-md-12 mt-3">
-
-    <h3 style="color: #45c545;">Account Transaction Master</h3>
-</div>
-
-<div class="row col-md-12 mt-3">
-    <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Account No</th>
-                <th>Account Title</th>
-                <th>Customer Name</th>
-                <th>DOB</th>
-                <th>Cell</th>
-                <th>CNIC</th>
-                <th>CNIC Expiry</th>
-                <th>Account Type</th>
-                <th>Account Category</th>
-                <th>Transaction Master Code</th>
-                <th>Transaction Master Desc</th>
-                <th colspan="3"></th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
-</div>@{
-    ViewData["Title"] = "List of Samples";
-    Layout = "_Layout";
-}
-
-<script type="text/javascript">
-    var g_engID = 0;
-    $(document).ready(function () {
-        var url_string = window.location;
-        var url = new URL(url_string);
-        g_engID = url.searchParams.get("engId");
-        loadBIOMETSamples();
-    });
-
-
-    function loadBIOMETSamples() {
-       destroyDatatable('biomet_sample_list');
-        $.ajax({
-             url: g_asiBaseURL + "/ApiCalls/get_biomet_sampling_details",
-            type: "POST",
-            data: { ENG_ID: '1828' },
-            success: function (data) {
-                if (data.length > 0) {
-                    populateTable(data);
-                }
-            },
-            error: function (xhr, status, error) {
-                console.error("Error fetching data:", error);
-            }
-        });
-    }
-        function populateTable(data) {
-        var tableBody = $("#biomet_sample_list tbody");
-        tableBody.empty(); // Clear existing rows
-
-        $.each(data, function (index, item) {
-            var row = `<tr>
-                <td>${index + 1}</td>
-                <td>${item.acNo}</td>
-                <td>${item.acTitle}</td>
-                <td>${item.custName}</td>
-                <td>${formatDate(item.dob)}</td>
-                <td>${item.cell}</td>
-                <td>${item.cnic}</td>
-                <td>${formatDate(item.cnicExpiry)}</td>
-                <td>${item.acType}</td>
-                <td>${item.acCat}</td>
-                <td>
-                    <a href="./account_document?acNo=${item.acNo}" class="btn btn-primary btn-sm">Documents</a>
-                </td>
-                <td>
-                    <a href="./account_transaction?acNo=${item.acNo}" class="btn btn-success btn-sm">Transactions</a>
-                </td>
-                <td>
-                    <a href="./account_transaction_master?acNo=${item.acNo}" class="btn btn-warning btn-sm">Master</a>
-                </td>
-            </tr>`;
-            tableBody.append(row);
-        });
-
-        initializeDataTable('biomet_sample_list');
-    }
-        function formatDate(dateString) {
-        if (!dateString || dateString.trim() === "") return "";
-        let date = new Date(dateString);
-        return date.toLocaleDateString(); // Adjust format as needed
-    }
-
-
-
-</script>
-
-<div class="row col-md-12 mt-3">
-
-    <h3 style="color: #45c545;">Account Transaction Master</h3>
-</div>
-
-<div class="row col-md-12 mt-3">
-    <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Account No</th>
-                <th>Account Title</th>
-                <th>Customer Name</th>
-                <th>DOB</th>
-                <th>Cell</th>
-                <th>CNIC</th>
-                <th>CNIC Expiry</th>
-                <th>Account Type</th>
-                <th>Account Category</th>
-                <th>Transaction Master Code</th>
-                <th>Transaction Master Desc</th>
-                <th colspan="3"></th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Account Transaction Master</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Sr No</th>
+                            <th>Account No</th>
+                            <th>Account Title</th>
+                            <th>Customer Name</th>
+                            <th>DOB</th>
+                            <th>Cell</th>
+                            <th>CNIC</th>
+                            <th>CNIC Expiry</th>
+                            <th>Account Type</th>
+                            <th>Account Category</th>
+                            <th>Transaction Master Code</th>
+                            <th>Transaction Master Desc</th>
+                            <th colspan="3"></th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>

--- a/AIS/AIS/Views/Sampling/biomet.cshtml
+++ b/AIS/AIS/Views/Sampling/biomet.cshtml
@@ -72,30 +72,34 @@
     }
 
 </script>
-
-<div class="row col-md-12 mt-3">
-
-    <h3 style="color: #45c545;">Biomet Samples</h3>
-</div>
-
-<div class="row col-md-12 mt-3">
-    <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Account No</th>
-                <th>Account Title</th>
-                <th>Customer Name</th>
-                <th>DOB</th>
-                <th>Cell</th>
-                <th>CNIC</th>
-                <th>CNIC Expiry</th>
-                <th>Account Type</th>
-                <th>Account Category</th>
-                <th></th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Biomet Samples</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Sr No</th>
+                            <th>Account No</th>
+                            <th>Account Title</th>
+                            <th>Customer Name</th>
+                            <th>DOB</th>
+                            <th>Cell</th>
+                            <th>CNIC</th>
+                            <th>CNIC Expiry</th>
+                            <th>Account Type</th>
+                            <th>Account Category</th>
+                            <th></th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>

--- a/AIS/AIS/Views/Sampling/list_reports.cshtml
+++ b/AIS/AIS/Views/Sampling/list_reports.cshtml
@@ -78,28 +78,26 @@
     }
 
 </script>
-
-<div class="row col-md-12 mt-3">
-
-    <h3 style="color: #45c545;">List of Exception Reports</h3>
-
-    <div class="row col-md-12 mt-3">
-
-        <table id="listOfSamples" class="table table-hover table-bordered table-hover mt-3 table-striped">
-            <thead style="background-color: rgb(181 229 117 / 93%) !important; ">
-                <tr>
-                    <th class="col-md-auto">Sr. No.</th>
-                    <th class="col-md-auto">Report Name List</th>
-                    <th class="col-md-auto">Things to be checked</th>
-                    <th class="col-md-auto text-center">View</th>
-                </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
- 
-        
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">List of Exception Reports</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="listOfSamples" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th class="col-md-auto">Sr. No.</th>
+                            <th class="col-md-auto">Report Name List</th>
+                            <th class="col-md-auto">Things to be checked</th>
+                            <th class="col-md-auto text-center">View</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
     </div>
-
-  
 </div>

--- a/AIS/AIS/Views/Sampling/list_samples.cshtml
+++ b/AIS/AIS/Views/Sampling/list_samples.cshtml
@@ -77,32 +77,30 @@
 
         window.location.href = g_asiBaseURL + "/Sampling/loans?engId="+g_engID+"&sample_id="+sampleId+"&loan_status="+loanStatus
     }
-
 </script>
+<link rel="stylesheet" href="~/css/sampling.css" />
 
-<div class="row col-md-12 mt-3">
-
-    <h3 style="color: #45c545;">List of Samples</h3>
-
-    <div class="row col-md-12 mt-3">
-
-        <table id="listOfSamples" class="table table-hover table-bordered table-hover mt-3 table-striped">
-            <thead style="background-color: rgb(181 229 117 / 93%) !important; ">
-                <tr>
-                    <th class="col-md-auto">Sr. No.</th>
-                    <th class="col-md-auto">Sample List</th>
-                    <th class="col-md-auto">Percentage</th>
-                    <th class="col-md-auto">Total Count</th>
-                    <th class="col-md-auto">Sample Count</th>
-                    <th class="col-md-auto text-center">View</th>
-                </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
- 
-        
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">List of Samples</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="listOfSamples" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th class="col-md-auto">Sr. No.</th>
+                            <th class="col-md-auto">Sample List</th>
+                            <th class="col-md-auto">Percentage</th>
+                            <th class="col-md-auto">Total Count</th>
+                            <th class="col-md-auto">Sample Count</th>
+                            <th class="col-md-auto text-center">View</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
     </div>
-
-  
 </div>

--- a/AIS/AIS/Views/Sampling/loan_documents.cshtml
+++ b/AIS/AIS/Views/Sampling/loan_documents.cshtml
@@ -111,23 +111,28 @@
     }
 
 </script>
-
-<div class="row col-md-12 mt-3">
-    <h3 style="color: #45c545;">Loan Documents List</h3>
-</div>
-
-<div class="row col-md-12 mt-3">
-    <table id="loan_document_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Branch Code</th>                
-                <th>Loan Case</th>                
-                <th>Customer Name</th>
-                <th>Document Name</th>
-                <th>Action</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Loan Documents List</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="loan_document_list" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Sr No</th>
+                            <th>Branch Code</th>
+                            <th>Loan Case</th>
+                            <th>Customer Name</th>
+                            <th>Document Name</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>

--- a/AIS/AIS/Views/Sampling/loan_transactions.cshtml
+++ b/AIS/AIS/Views/Sampling/loan_transactions.cshtml
@@ -72,30 +72,35 @@
         return amount ? parseFloat(amount).toFixed(2) : "0.00";
     }
 </script>
-
-<div class="row col-md-12 mt-3">
-    <h3 style="color: #45c545;">Loan Transactions</h3>
-</div>
-
-<div class="row col-md-12 mt-3">
-    <table id="account_transaction_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Loan Account ID</th>
-                <th>Manual Voucher No</th>
-                <th>Description</th>             
-                <th>Transaction Date</th>
-                <th>Debit Amount</th>
-                <th>Credit Amount</th>                
-                <th>MCO Receipt No</th>
-                <th>MCO Book No</th>
-                <th>Authorization Date</th>
-                <th>Rejection Date</th>
-                <th>Reversal Date</th>
-                <th>Remarks</th>
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Loan Transactions</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="account_transaction_list" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Sr No</th>
+                            <th>Loan Account ID</th>
+                            <th>Manual Voucher No</th>
+                            <th>Description</th>
+                            <th>Transaction Date</th>
+                            <th>Debit Amount</th>
+                            <th>Credit Amount</th>
+                            <th>MCO Receipt No</th>
+                            <th>MCO Book No</th>
+                            <th>Authorization Date</th>
+                            <th>Rejection Date</th>
+                            <th>Reversal Date</th>
+                            <th>Remarks</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>

--- a/AIS/AIS/Views/Sampling/loans.cshtml
+++ b/AIS/AIS/Views/Sampling/loans.cshtml
@@ -88,32 +88,35 @@
     }
 
 </script>
-
-<div class="row col-md-12 mt-3">
-
-    <h3 style="color: #45c545;">Loan Samples</h3>
-</div>
-
-<div class="row col-md-12 mt-3">
-    <table id="loan_sample_list" class="table table-hover table-bordered table-striped">
-        <thead style="background-color: rgb(181 229 117 / 93%) !important;">
-            <tr>
-                <th>Sr No</th>
-                <th>Type</th>
-                <th>Scheme</th>
-                <th>Purpose</th>
-                <th>LC No</th>
-                <th>CNIC</th>
-                <th>Customer Name</th>
-                <th>Application Date</th>
-                <th>Disbursement Date</th>
-                <th>Disbursement Amount</th>
-                <th>Current Outstanding</th>
-                <th></th>
-                <th></th>
-
-            </tr>
-        </thead>
-        <tbody></tbody>
-    </table>
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Loan Samples</h4>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table id="loan_sample_list" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Sr No</th>
+                            <th>Type</th>
+                            <th>Scheme</th>
+                            <th>Purpose</th>
+                            <th>LC No</th>
+                            <th>CNIC</th>
+                            <th>Customer Name</th>
+                            <th>Application Date</th>
+                            <th>Disbursement Date</th>
+                            <th>Disbursement Amount</th>
+                            <th>Current Outstanding</th>
+                            <th></th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>

--- a/AIS/AIS/Views/Sampling/sample_monitoring.cshtml
+++ b/AIS/AIS/Views/Sampling/sample_monitoring.cshtml
@@ -104,45 +104,44 @@
     }
 
 </script>
-
-<div class="row col-md-12 mt-3">
-
-    <h3 style="color: #45c545;">Monitoring of Samples</h3>
-
-    <div class="row col-md-12 mt-1">
-        <label>Entity:</label>
-        <select id="entitySelectField" onchange="listSamples();" class="form-select form-control">
-            <option value="0" id="0" selected>--Select Entity Name--</option>
-            @{
-                if (ViewData["EntityList"] != null)
-                    {
-                    foreach (var ent in (dynamic)(ViewData["EntityList"]))
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Monitoring of Samples</h4>
+        </div>
+        <div class="card-body">
+            <div class="mb-3">
+                <label>Entity:</label>
+                <select id="entitySelectField" onchange="listSamples();" class="form-select form-control">
+                    <option value="0" id="0" selected>--Select Entity Name--</option>
+                    @{
+                        if (ViewData["EntityList"] != null)
                         {
-                        <option id="@ent.ENG_ID" value="@ent.ENG_ID">@ent.NAME</option>
+                            foreach (var ent in (dynamic)(ViewData["EntityList"]))
+                            {
+                                <option id="@ent.ENG_ID" value="@ent.ENG_ID">@ent.NAME</option>
+                            }
                         }
                     }
-            }
-        </select>
+                </select>
+            </div>
+            <div class="table-responsive">
+                <table id="listOfSamples" class="table table-hover table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th class="col-md-auto">Sr. No.</th>
+                            <th class="col-md-auto">Sample List</th>
+                            <th class="col-md-auto">Percentage</th>
+                            <th class="col-md-auto">Total Count</th>
+                            <th class="col-md-auto">Sample Count</th>
+                            <th class="col-md-auto text-center">View</th>
+                            <th class="col-md-auto text-center">Regenerate Sample</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
     </div>
-
-
-    <div class="row col-md-12 mt-3">
-        <table id="listOfSamples" class="table table-hover table-bordered table-hover mt-3 table-striped">
-            <thead style="background-color: rgb(181 229 117 / 93%) !important; ">
-                <tr>
-                    <th class="col-md-auto">Sr. No.</th>
-                    <th class="col-md-auto">Sample List</th>
-                    <th class="col-md-auto">Percentage</th>
-                    <th class="col-md-auto">Total Count</th>
-                    <th class="col-md-auto">Sample Count</th>
-                    <th class="col-md-auto text-center">View</th>
-                    <th class="col-md-auto text-center">Regenerate Sample</th>
-                </tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
-    </div>
-
-
 </div>

--- a/AIS/AIS/wwwroot/css/sampling.css
+++ b/AIS/AIS/wwwroot/css/sampling.css
@@ -1,0 +1,12 @@
+.card-sample {
+    border: 1px solid #b5e575;
+    border-radius: 0.25rem;
+}
+.card-sample .card-header {
+    background-color: #b5e575;
+    color: #1b1b1b;
+    font-weight: 600;
+}
+.card-sample .table-responsive {
+    margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- restyle sampling views with a Bootstrap card layout
- add shared `sampling.css` stylesheet for sampling pages

## Testing
- `dotnet build AIS/AIS.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405f58eae4832ebc03d76869f0d352