### PR TITLE
Center home image and shrink footer

### DIFF
--- a/AIS/AIS/Views/Home/Index.cshtml
+++ b/AIS/AIS/Views/Home/Index.cshtml
@@ -18,9 +18,8 @@
 
 
 
-<div class="row col-md-10 align-content-center">
-    <div class="col-md-6 mt-3 p-10 align-content-center ">
-        <img class="w-100 align-content-md-center" src="~/Images/home.png">
-        </div>
-    
+<div class="row justify-content-center">
+    <div class="col-md-8 text-center mt-3">
+        <img class="img-fluid mx-auto d-block" src="~/Images/home.png" alt="Home Image" />
+    </div>
 </div>

--- a/AIS/AIS/wwwroot/css/site.css
+++ b/AIS/AIS/wwwroot/css/site.css
@@ -133,7 +133,7 @@ html {
 
 body {
     /* Margin bottom by footer height */
-    margin-bottom: 60px;
+    margin-bottom: 30px;
 }
 
 .footer {
@@ -141,7 +141,7 @@ body {
     bottom: 0;
     width: 100%;
     white-space: nowrap;
-    line-height: 60px; /* Vertically center the text there */
+    line-height: 30px; /* Vertically center the text there */
 }
 
 @keyframes loading-1 {


### PR DESCRIPTION
## Summary
- center the home page image and make it responsive
- reduce footer height via CSS

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406a00af44832e974d3ac1fa2193ad