### PR TITLE
Polyfill DataTables for Buttons

### DIFF
--- a/AIS/AIS/wwwroot/lib/datatable/datatables.min.js
+++ b/AIS/AIS/wwwroot/lib/datatable/datatables.min.js
@@ -19,3 +19,4 @@
  * © SpryMedia Ltd - datatables.net/license
  */
 !function (t) { var o, d; "function" == typeof define && define.amd ? define(["jquery", "datatables.net"], function (e) { return t(e, window, document) }) : "object" == typeof exports ? (o = require("jquery"), d = function (e, n) { n.fn.dataTable || require("datatables.net")(e, n) }, "undefined" == typeof window ? module.exports = function (e, n) { return e = e || window, n = n || o(e), d(e, n), t(n, 0, e.document) } : (d(window, o), module.exports = t(o, window, window.document))) : t(jQuery, window, document) }(function (e, n, t) { "use strict"; return e.fn.dataTable });
+\n(function(){var dt=jQuery.fn.dataTable; if(dt && !dt.ext.features.register && dt.feature && dt.feature.register){dt.ext.features.register=dt.feature.register;}})();


### PR DESCRIPTION
## Summary
- polyfill `features.register` so Buttons 2.2.2 works with DataTables 2.1.3

## Testing
- `dotnet build AIS/AIS.sln -v minimal` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840e9d5758c832e994d489178842f09