### PR TITLE
Add sampling add report view and improve layout

### DIFF
--- a/AIS/AIS/AIS.csproj
+++ b/AIS/AIS/AIS.csproj
@@ -50,6 +50,10 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    <Content Update="Views\Sampling\add_report.cshtml">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
     <Content Update="Views\Execution\manage_audit_paras_authorized.cshtml">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/AIS/AIS/Controllers/SamplingController.cs
+++ b/AIS/AIS/Controllers/SamplingController.cs
@@ -59,6 +59,25 @@ namespace AIS.Controllers
                     return View();
                 }
             }
+
+        public IActionResult add_report()
+            {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                {
+                return RedirectToAction("Index", "Login");
+                }
+            else
+                {
+                if (!sessionHandler.HasPermissionToViewPage(MethodBase.GetCurrentMethod().Name))
+                    {
+                    return RedirectToAction("Index", "PageNotFound");
+                    }
+                else
+                    return View();
+                }
+            }
         public IActionResult biomet()
             {
             ViewData["TopMenu"] = tm.GetTopMenus();

--- a/AIS/AIS/Views/Dashboard/audit_performance.cshtml
+++ b/AIS/AIS/Views/Dashboard/audit_performance.cshtml
@@ -51,13 +51,16 @@
                     $('#chart-container').append('<div class="col-md-4 mb-4"><div class="card shadow-sm"><div class="card-body"><h6 class="text-center">' + v.title + '</h6><div id="' + chartId + '" style="height:250px;"></div><p class="mt-2 text-center font-weight-bold">Ratio: ' + parseFloat(v.ratio).toFixed(2) + '%</p></div></div></div>');
                     var chart = new CanvasJS.Chart(chartId, {
                         animationEnabled: true,
-                        axisY: { title: 'Paras' },
+                        legend: {
+                            verticalAlign: "center",
+                            horizontalAlign: "left"
+                        },
                         data: [{
-                            type: 'column',
+                            type: 'doughnut',
+                            indexLabel: '{label} - {y}',
                             dataPoints: [
-                                { label: 'Total Paras', y: parseInt(v.total_Paras) },
-                                { label: 'Settled', y: parseInt(v.setteled_Para) },
-                                { label: 'Unsettled', y: parseInt(v.unsetteled_Para) }
+                                { label: 'Settled', y: parseInt(v.setteled_Para), color: '#82f386' },
+                                { label: 'Unsettled', y: parseInt(v.unsetteled_Para), color: '#ff968f' }
                             ]
                         }]
                     });

--- a/AIS/AIS/Views/Engagement/task_list.cshtml
+++ b/AIS/AIS/Views/Engagement/task_list.cshtml
@@ -17,7 +17,7 @@
             <div class="card shadow-sm">
                 <div class="card-body p-0">
                     <div class="table-responsive">
-                    <table id="taskListTable" class="table table-hover table-bordered table-striped table-sm text-nowrap mb-0">
+                    <table id="taskListTable" class="table table-hover table-bordered table-striped table-sm mb-0 w-100">
                         <thead style="background-color: rgb(181 229 117 / 93%) !important; ">
                             <tr>
                                 <th class="font-weight-bold text-center" width="5%">Sr. No</th>

--- a/AIS/AIS/Views/Sampling/add_report.cshtml
+++ b/AIS/AIS/Views/Sampling/add_report.cshtml
@@ -1,0 +1,25 @@
+@{
+    ViewData["Title"] = "Add Exception Report";
+    Layout = "_Layout";
+}
+<link rel="stylesheet" href="~/css/sampling.css" />
+<div class="container-fluid mt-4">
+    <div class="card card-sample shadow-sm">
+        <div class="card-header">
+            <h4 class="mb-0">Add Exception Report</h4>
+        </div>
+        <div class="card-body">
+            <form>
+                <div class="mb-3">
+                    <label class="form-label">Report Name List</label>
+                    <input type="text" class="form-control" />
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Things to be checked</label>
+                    <textarea class="form-control" rows="4"></textarea>
+                </div>
+                <button type="submit" class="btn btn-success">Save</button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/AIS/AIS/Views/Sampling/list_reports.cshtml
+++ b/AIS/AIS/Views/Sampling/list_reports.cshtml
@@ -81,8 +81,9 @@
 <link rel="stylesheet" href="~/css/sampling.css" />
 <div class="container-fluid mt-4">
     <div class="card card-sample shadow-sm">
-        <div class="card-header">
+        <div class="card-header d-flex justify-content-between align-items-center">
             <h4 class="mb-0">List of Exception Reports</h4>
+            <a class="btn btn-sm btn-primary" href="@Url.Action("add_report","Sampling")">Add Report</a>
         </div>
         <div class="card-body">
             <div class="table-responsive">


### PR DESCRIPTION
## Summary
- adjust Engagement task list table to fit screen
- redesign audit performance charts to doughnut style
- add Add Report view for Sampling with link from list
- register new view in project

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841621b3894832ea86e1847d47ea7b7