### PR TITLE
Improve task table layout and home image

### DIFF
--- a/AIS/AIS/Views/Engagement/task_list.cshtml
+++ b/AIS/AIS/Views/Engagement/task_list.cshtml
@@ -5,8 +5,13 @@
 <style type="text/css">
     .strike-out {
         text-decoration: line-through !important;
-    }</style>
-<div class="container mt-4">
+    }
+    #taskListTable th,
+    #taskListTable td {
+        text-align: left !important;
+    }
+</style>
+<div class="container-fluid mt-4">
     <div class="row">
         <div class="col-md-12">
             <h3 class="text-success">Task List/Job Assignment</h3>
@@ -21,7 +26,6 @@
                         <thead style="background-color: rgb(181 229 117 / 93%) !important; ">
                             <tr>
                                 <th class="font-weight-bold text-center" width="5%">Sr. No</th>
-                                <th class="col-md-2 font-weight-bold text-Left">Reporting</th>
                                 <th class="col-md-auto font-weight-bold text-left">Audit Entity</th>
                                 <th class="col-md-auto font-weight-bold text-center">Start Date</th>
                                 <th class="col-md-auto font-weight-bold text-center">End Date</th>
@@ -39,12 +43,9 @@
                                     {
                                         var sDate = item.AUDIT_START_DATE.ToString();
                                         var eDate = item.AUDIT_END_DATE.ToString();
-                                        var osdate = item.OPERATION_STARTDATE.ToString();
-                                        var oedate = item.OPERATION_ENDDATE.ToString();
 
                                         <tr>
                                             <td class="text-center" style="width:50px">@index</td>
-                                             <td class="col-md-auto text-center">@item.REPORTING</td>
                                             <td class="col-md-auto text-center">@item.ENTITY_NAME</td>
                                             <td class="col-md-1 text-center">@sDate.Split(" ")[0]</td>
                                             <td class="col-md-1 text-center">@eDate.Split(" ")[0]</td>

--- a/AIS/AIS/Views/Home/Index.cshtml
+++ b/AIS/AIS/Views/Home/Index.cshtml
@@ -13,7 +13,7 @@
         justify-content:center;
     }
     .home-wrapper img{
-        max-width:100%;
+        max-width:70%;
         height:auto;
     }
 </style>


### PR DESCRIPTION
## Summary
- make Home page image smaller
- widen task list table using `container-fluid`
- remove unused `Reporting` column
- left align task list cells

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416b88eefc832e9a066c8afb880f16