### PR TITLE
Fix JSON serialization for FAD observation view

### DIFF
--- a/AIS/AIS/Startup.cs
+++ b/AIS/AIS/Startup.cs
@@ -31,7 +31,14 @@ namespace AIS
             services.AddScoped<SessionHandler>();
             services.AddScoped<DBConnection>();
             services.AddScoped<TopMenus>();
-            services.AddControllersWithViews().AddRazorRuntimeCompilation();
+            services.AddControllersWithViews()
+                    .AddJsonOptions(options =>
+                    {
+                        options.JsonSerializerOptions.PropertyNamingPolicy = null;
+                        options.JsonSerializerOptions.DictionaryKeyPolicy = null;
+                        options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
+                    })
+                    .AddRazorRuntimeCompilation();
             services.AddHttpContextAccessor();
 
 


### PR DESCRIPTION
## Summary
- ensure API responses keep original property names by disabling JSON camel-casing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847ad1e8ed0832eb302c859af7dd2ed