### PR TITLE
Add report title parameter for sampling views

### DIFF
--- a/AIS/AIS/Views/Sampling/Account_exception.cshtml
+++ b/AIS/AIS/Views/Sampling/Account_exception.cshtml
@@ -1,5 +1,6 @@
 ﻿@{
-    ViewData["Title"] = "CTR Reports Related to Accounts";
+    var passedTitle = Context.Request.Query["title"].ToString();
+    ViewData["Title"] = string.IsNullOrEmpty(passedTitle) ? "CTR Reports Related to Accounts" : passedTitle;
     Layout = "_Layout";
 }
 

--- a/AIS/AIS/Views/Sampling/list_reports.cshtml
+++ b/AIS/AIS/Views/Sampling/list_reports.cshtml
@@ -38,13 +38,13 @@
         let tableBody = $("#listOfSamples tbody");
                  
 
-         data.forEach((item, index) => {
+        data.forEach((item, index) => {
         let row = `<tr>
             <td>${index + 1}</td>
             <td>${item.reporT_TITLE}</td>
             <td class="text-center">${item.discription}</td>
             <td class="text-center">
-                <button class="btn btn-danger btn-sm" onclick="viewSample(${item.reporT_ID}, ${item.loaN_STATUS}, '${item.reporT_INDICATOR}')">                
+                <button class="btn btn-danger btn-sm" onclick="viewSample(${item.reporT_ID}, ${item.loaN_STATUS}, '${item.reporT_INDICATOR}', '${item.reporT_TITLE.replace(/'/g, "\\'")}')">
                     View
                 </button>
             </td>
@@ -58,23 +58,21 @@
         $('#wait').hide();
     }
 
-    function viewSample(reportId, loanStatus, indicator) {
+    function viewSample(reportId, loanStatus, indicator, reportTitle) {
         if(indicator=="A"){
-            redirectToAccount(reportId,loanStatus);
+            redirectToAccount(reportId,loanStatus, reportTitle);
         }else if(indicator=="L"){
-            redirectToLoan(reportId,loanStatus);
+            redirectToLoan(reportId,loanStatus, reportTitle);
         }
     }
 
 
 
-    function redirectToAccount(reportId,loanStatus){
-        
-        window.location.href = g_asiBaseURL + "/Sampling/Account_exception?engId="+g_engID+"&report_id="+reportId+"&loan_status="+loanStatus;
+    function redirectToAccount(reportId, loanStatus, title){
+        window.location.href = g_asiBaseURL + "/Sampling/Account_exception?engId="+g_engID+"&report_id="+reportId+"&loan_status="+loanStatus+"&title="+encodeURIComponent(title);
     }
-      function redirectToLoan(reportId,loanStatus){
-
-        window.location.href = g_asiBaseURL + "/Sampling/loans?engId="+g_engID+"&reporT_ID="+reportId+"&loaN_STATUS="+loanStatus
+      function redirectToLoan(reportId, loanStatus, title){
+        window.location.href = g_asiBaseURL + "/Sampling/loans?engId="+g_engID+"&reporT_ID="+reportId+"&loaN_STATUS="+loanStatus+"&title="+encodeURIComponent(title);
     }
 
 </script>

--- a/AIS/AIS/Views/Sampling/loans.cshtml
+++ b/AIS/AIS/Views/Sampling/loans.cshtml
@@ -1,5 +1,6 @@
 ﻿@{
-    ViewData["Title"] = "Samples of Loans";
+    var passedTitle = Context.Request.Query["title"].ToString();
+    ViewData["Title"] = string.IsNullOrEmpty(passedTitle) ? "Samples of Loans" : passedTitle;
     Layout = "_Layout";
 }
 


### PR DESCRIPTION
## Summary
- forward `reporT_TITLE` when navigating from list reports
- read `title` query parameter in Account_exception and loans views

## Testing
- `dotnet test AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdb1aff0c832ea1980fb885591cad