### PR TITLE
Carry report description in links

### DIFF
--- a/AIS/AIS/Views/Sampling/Account_exception.cshtml
+++ b/AIS/AIS/Views/Sampling/Account_exception.cshtml
@@ -1,6 +1,8 @@
 ﻿@{
     var passedTitle = Context.Request.Query["title"].ToString();
+    var passedDesc = Context.Request.Query["desc"].ToString();
     ViewData["Title"] = string.IsNullOrEmpty(passedTitle) ? "CTR Reports Related to Accounts" : passedTitle;
+    ViewData["Description"] = passedDesc;
     Layout = "_Layout";
 }
 
@@ -76,6 +78,10 @@
             <h4 class="mb-0">@ViewData["Title"]</h4>
         </div>
         <div class="card-body">
+            @if(!string.IsNullOrWhiteSpace(ViewData["Description"] as string))
+            {
+                <p class="font-weight-bold text-danger">@ViewData["Description"]</p>
+            }
             <div class="table-responsive">
                 <table id="biomet_sample_list" class="table table-hover table-bordered table-striped">
                     <thead>

--- a/AIS/AIS/Views/Sampling/list_reports.cshtml
+++ b/AIS/AIS/Views/Sampling/list_reports.cshtml
@@ -44,7 +44,7 @@
             <td>${item.reporT_TITLE}</td>
             <td class="text-center">${item.discription}</td>
             <td class="text-center">
-                <button class="btn btn-danger btn-sm" onclick="viewSample(${item.reporT_ID}, ${item.loaN_STATUS}, '${item.reporT_INDICATOR}', '${item.reporT_TITLE.replace(/'/g, "\\'")}')">
+                <button class="btn btn-danger btn-sm" onclick="viewSample(${item.reporT_ID}, ${item.loaN_STATUS}, '${item.reporT_INDICATOR}', '${item.reporT_TITLE.replace(/'/g, "\\'")}', '${item.discription.replace(/'/g, "\\'")}')">
                     View
                 </button>
             </td>
@@ -58,21 +58,21 @@
         $('#wait').hide();
     }
 
-    function viewSample(reportId, loanStatus, indicator, reportTitle) {
+    function viewSample(reportId, loanStatus, indicator, reportTitle, reportDescription) {
         if(indicator=="A"){
-            redirectToAccount(reportId,loanStatus, reportTitle);
+            redirectToAccount(reportId, loanStatus, reportTitle, reportDescription);
         }else if(indicator=="L"){
-            redirectToLoan(reportId,loanStatus, reportTitle);
+            redirectToLoan(reportId, loanStatus, reportTitle, reportDescription);
         }
     }
 
 
 
-    function redirectToAccount(reportId, loanStatus, title){
-        window.location.href = g_asiBaseURL + "/Sampling/Account_exception?engId="+g_engID+"&report_id="+reportId+"&loan_status="+loanStatus+"&title="+encodeURIComponent(title);
+    function redirectToAccount(reportId, loanStatus, title, desc){
+        window.location.href = g_asiBaseURL + "/Sampling/Account_exception?engId="+g_engID+"&report_id="+reportId+"&loan_status="+loanStatus+"&title="+encodeURIComponent(title)+"&desc="+encodeURIComponent(desc);
     }
-      function redirectToLoan(reportId, loanStatus, title){
-        window.location.href = g_asiBaseURL + "/Sampling/loans_exception?engId="+g_engID+"&reporT_ID="+reportId+"&loaN_STATUS="+loanStatus+"&title="+encodeURIComponent(title);
+      function redirectToLoan(reportId, loanStatus, title, desc){
+        window.location.href = g_asiBaseURL + "/Sampling/loans_exception?engId="+g_engID+"&reporT_ID="+reportId+"&loaN_STATUS="+loanStatus+"&title="+encodeURIComponent(title)+"&desc="+encodeURIComponent(desc);
     }
 
 </script>

--- a/AIS/AIS/Views/Sampling/loans _exception.cshtml
+++ b/AIS/AIS/Views/Sampling/loans _exception.cshtml
@@ -1,6 +1,8 @@
 ﻿@{
     var passedTitle = Context.Request.Query["title"].ToString();
+    var passedDesc = Context.Request.Query["desc"].ToString();
     ViewData["Title"] = string.IsNullOrEmpty(passedTitle) ? "Samples of Loans" : passedTitle;
+    ViewData["Description"] = passedDesc;
     Layout = "_Layout";
 }
 
@@ -96,6 +98,10 @@
             <h4 class="mb-0">@ViewData["Title"]</h4>
         </div>
         <div class="card-body">
+            @if(!string.IsNullOrWhiteSpace(ViewData["Description"] as string))
+            {
+                <p class="font-weight-bold text-danger">@ViewData["Description"]</p>
+            }
             <div class="table-responsive">
                 <table id="loan_sample_list" class="table table-hover table-bordered table-striped">
                     <thead>


### PR DESCRIPTION
## Summary
- send report description as query parameter when navigating from sampling report list
- show the passed description in Account_exception and loans_exception views

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be365cb34832eaeb38ffd887b9935