### PR TITLE
Fix responsible persons loading for branch observation updates

### DIFF
--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -399,10 +399,11 @@
     function ObservationResponsibles() {
         $('#update_listofRespPersons tbody').empty();
         $.ajax({
-            url: g_asiBaseURL + "/ApiCalls/get_observation_responsible_ppnos",
+            url: g_asiBaseURL + "/ApiCalls/get_responsible_person_list",
             type: "POST",
             data: {
-                'OBS_ID': g_obsId
+                'PARA_ID': g_obsId,
+                'INDICATOR': g_ind
             },
             cache: false,
             success: function (data) {


### PR DESCRIPTION
## Summary
- fetch responsible persons for branch observations via `get_responsible_person_list`
- preserve ability to add/update/delete responsibles on branch para text

## Testing
- `dotnet build AIS.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685233854c70832eabcc7e8ef9163c2d