### PR TITLE
Fix dropdown toggles and duplicate modal icons

### DIFF
--- a/AIS/AIS/Views/AdministrationPanel/entity_heirarchy.cshtml
+++ b/AIS/AIS/Views/AdministrationPanel/entity_heirarchy.cshtml
@@ -11,8 +11,8 @@
             <div class="card-header" id="headingAuditDivision">
                 <h5 class="mb-0">
                     <button class="btn btn-link"
-                            data-toggle="collapse"
-                            data-target="#collapseAuditDivision"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapseAuditDivision"
                             aria-expanded="true"
                             aria-controls="collapseAuditDivision">
                         Audit Division
@@ -31,8 +31,8 @@
                             <div class="card-header" id="headingISAudit">
                                 <h5 class="mb-0">
                                     <button class="btn btn-link collapsed"
-                                            data-toggle="collapse"
-                                            data-target="#collapseISAudit"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#collapseISAudit"
                                             aria-expanded="false"
                                             aria-controls="collapseISAudit">
                                         Information System Audit
@@ -58,8 +58,8 @@
                             <div class="card-header" id="headingCorporateAudit">
                                 <h5 class="mb-0">
                                     <button class="btn btn-link collapsed"
-                                            data-toggle="collapse"
-                                            data-target="#collapseCorporateAudit"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#collapseCorporateAudit"
                                             aria-expanded="false"
                                             aria-controls="collapseCorporateAudit">
                                         Corporate Audit
@@ -85,8 +85,8 @@
                             <div class="card-header" id="headingFieldAudit">
                                 <h5 class="mb-0">
                                     <button class="btn btn-link collapsed"
-                                            data-toggle="collapse"
-                                            data-target="#collapseFieldAudit"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#collapseFieldAudit"
                                             aria-expanded="false"
                                             aria-controls="collapseFieldAudit">
                                         Field Audit
@@ -116,8 +116,8 @@
             <div class="card-header" id="headingHRDivision">
                 <h5 class="mb-0">
                     <button class="btn btn-link"
-                            data-toggle="collapse"
-                            data-target="#collapseHRDivision"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#collapseHRDivision"
                             aria-expanded="false"
                             aria-controls="collapseHRDivision">
                         HR Division
@@ -136,8 +136,8 @@
                             <div class="card-header" id="headingRecruitment">
                                 <h5 class="mb-0">
                                     <button class="btn btn-link collapsed"
-                                            data-toggle="collapse"
-                                            data-target="#collapseRecruitment"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#collapseRecruitment"
                                             aria-expanded="false"
                                             aria-controls="collapseRecruitment">
                                         Recruitment
@@ -163,8 +163,8 @@
                             <div class="card-header" id="headingEmployeeRelations">
                                 <h5 class="mb-0">
                                     <button class="btn btn-link collapsed"
-                                            data-toggle="collapse"
-                                            data-target="#collapseEmployeeRelations"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#collapseEmployeeRelations"
                                             aria-expanded="false"
                                             aria-controls="collapseEmployeeRelations">
                                         Employee Relations
@@ -190,8 +190,8 @@
                             <div class="card-header" id="headingTrainingDevelopment">
                                 <h5 class="mb-0">
                                     <button class="btn btn-link collapsed"
-                                            data-toggle="collapse"
-                                            data-target="#collapseTrainingDevelopment"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#collapseTrainingDevelopment"
                                             aria-expanded="false"
                                             aria-controls="collapseTrainingDevelopment">
                                         Training and Development

--- a/AIS/AIS/Views/AuditeePortal/Para_Text_Update_FAD.cshtml
+++ b/AIS/AIS/Views/AuditeePortal/Para_Text_Update_FAD.cshtml
@@ -211,7 +211,7 @@
                                 <!-- Buttons -->
                                 <div data-type="image-buttons" class="row justify-content-center mt-2">
                                     <button data-type="add" class="btn btn-outline-success" type="button" style="width:105px"><span class="fa fa-camera mr-2" style="padding-right:5px"></span>Add</button>
-                                    <button data-type="btn-modify" type="button" class="btn btn-outline-success m-0 " data-toggle="popover" data-placement="right" style="display:none; width:105px;">
+                                    <button data-type="btn-modify" type="button" class="btn btn-outline-success m-0 " data-bs-toggle="popover" data-bs-placement="right" style="display:none; width:105px;">
                                         <span class="fa fa-pencil-alt mr-2" style="padding-right:5px"></span>Modify
                                     </button>
                                 </div>

--- a/AIS/AIS/Views/CAU/OM/om_assignment.cshtml
+++ b/AIS/AIS/Views/CAU/OM/om_assignment.cshtml
@@ -262,7 +262,7 @@
         <div class="card">
             <div class="card-header" id="headingOne">
                 <h5 class="mb-0">
-                    <button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                    <button class="btn btn-link" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
                         OM STAGE
                     </button>
                 </h5>
@@ -344,7 +344,7 @@
         <div class="card">
             <div class="card-header" id="headingTwo">
                 <h5 class="mb-0">
-                    <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                    <button class="btn btn-link collapsed" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
                         AIR STAGE
                     </button>
                 </h5>
@@ -383,7 +383,7 @@
         <div class="card">
             <div class="card-header" id="headingThree">
                 <h5 class="mb-0">
-                    <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+                    <button class="btn btn-link collapsed" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
                         PDP STAGE
                     </button>
                 </h5>
@@ -433,7 +433,7 @@
         <div class="card">
             <div class="card-header" id="headingfive">
                 <h5 class="mb-0">
-                    <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseFour" aria-expanded="false" aria-controls="collapseThree">
+                    <button class="btn btn-link collapsed" data-bs-toggle="collapse" data-bs-target="#collapseFour" aria-expanded="false" aria-controls="collapseThree">
                         ARPSE STAGE
                     </button>
                 </h5>

--- a/AIS/AIS/Views/Dashboard/annex_wise_obs.cshtml
+++ b/AIS/AIS/Views/Dashboard/annex_wise_obs.cshtml
@@ -154,7 +154,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Paras Summary</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">
@@ -194,7 +194,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Detail</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">
@@ -234,7 +234,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">

--- a/AIS/AIS/Views/Dashboard/compliance_summary.cshtml
+++ b/AIS/AIS/Views/Dashboard/compliance_summary.cshtml
@@ -124,7 +124,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Paras Summary</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">
@@ -168,7 +168,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Detail</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">
@@ -208,7 +208,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">

--- a/AIS/AIS/Views/Dashboard/entity_wise_obs_detail.cshtml
+++ b/AIS/AIS/Views/Dashboard/entity_wise_obs_detail.cshtml
@@ -90,7 +90,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">

--- a/AIS/AIS/Views/Dashboard/functional_resp_wise_paras.cshtml
+++ b/AIS/AIS/Views/Dashboard/functional_resp_wise_paras.cshtml
@@ -127,7 +127,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">

--- a/AIS/AIS/Views/Dashboard/para_view.cshtml
+++ b/AIS/AIS/Views/Dashboard/para_view.cshtml
@@ -230,7 +230,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">

--- a/AIS/AIS/Views/Dashboard/serious_fraudulent_obs_gm.cshtml
+++ b/AIS/AIS/Views/Dashboard/serious_fraudulent_obs_gm.cshtml
@@ -109,7 +109,7 @@
             <div class="modal-header bg-success text-white">
                 <h5 class="modal-title">Details of Fraudulent A1 Para</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">

--- a/AIS/AIS/Views/PostCompliance/cau_post_compliance_to_branches.cshtml
+++ b/AIS/AIS/Views/PostCompliance/cau_post_compliance_to_branches.cshtml
@@ -217,7 +217,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Submission to Branch</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">

--- a/AIS/AIS/Views/PostCompliance/cau_post_compliance_to_branches_reply.cshtml
+++ b/AIS/AIS/Views/PostCompliance/cau_post_compliance_to_branches_reply.cshtml
@@ -382,7 +382,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Submission to Branch</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">

--- a/AIS/AIS/Views/PostCompliance/cau_post_compliance_to_branches_review.cshtml
+++ b/AIS/AIS/Views/PostCompliance/cau_post_compliance_to_branches_review.cshtml
@@ -296,7 +296,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Submission to Branch</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">

--- a/AIS/AIS/Views/PostCompliance/change_status_new_Para.cshtml
+++ b/AIS/AIS/Views/PostCompliance/change_status_new_Para.cshtml
@@ -138,7 +138,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Change Para Status</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">
@@ -186,7 +186,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">

--- a/AIS/AIS/Views/PostCompliance/change_status_new_Para_authorize.cshtml
+++ b/AIS/AIS/Views/PostCompliance/change_status_new_Para_authorize.cshtml
@@ -122,7 +122,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Auhtorization</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">
@@ -157,7 +157,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">

--- a/AIS/AIS/Views/PostCompliance/change_status_new_Para_reviewer.cshtml
+++ b/AIS/AIS/Views/PostCompliance/change_status_new_Para_reviewer.cshtml
@@ -123,7 +123,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Reviewer Remarks</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">
@@ -159,7 +159,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">

--- a/AIS/AIS/Views/PostCompliance/monitoring_of_para_settlement.cshtml
+++ b/AIS/AIS/Views/PostCompliance/monitoring_of_para_settlement.cshtml
@@ -205,7 +205,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Para Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="mt-3 modal-body">
@@ -234,7 +234,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Compliance History</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">
@@ -272,7 +272,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Compliance Text</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">
@@ -299,7 +299,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Comments</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">

--- a/AIS/AIS/Views/PostCompliance/post_compliance.cshtml
+++ b/AIS/AIS/Views/PostCompliance/post_compliance.cshtml
@@ -486,7 +486,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Compliance History</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">
@@ -524,7 +524,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">View Compliance</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">
@@ -594,7 +594,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Submit Compliance</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">

--- a/AIS/AIS/Views/PostCompliance/post_compliance_ho_monitoring.cshtml
+++ b/AIS/AIS/Views/PostCompliance/post_compliance_ho_monitoring.cshtml
@@ -388,7 +388,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Compliance History</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">
@@ -427,7 +427,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Observation</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">

--- a/AIS/AIS/Views/PostCompliance/post_compliance_review.cshtml
+++ b/AIS/AIS/Views/PostCompliance/post_compliance_review.cshtml
@@ -544,7 +544,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Compliance History</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">
@@ -582,7 +582,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Observation</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">
@@ -671,7 +671,7 @@
             <div class="modal-header bg-danger text-white">
                 <h5 class="modal-title">Observation</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    
                 </button>
             </div>
             <div class="modal-body">

--- a/AIS/AIS/Views/Reports/Audit_Period_Or_Entity_Wise_Report.cshtml
+++ b/AIS/AIS/Views/Reports/Audit_Period_Or_Entity_Wise_Report.cshtml
@@ -374,7 +374,7 @@
                                 <!-- Buttons -->
                                 <div data-type="image-buttons" class="row justify-content-center mt-2">
                                     <button data-type="add" class="btn btn-outline-success" type="button" style="width:105px"><span class="fa fa-camera mr-2" style="padding-right:5px"></span>Add</button>
-                                    <button data-type="btn-modify" type="button" class="btn btn-outline-success m-0 " data-toggle="popover" data-placement="right" style="display:none; width:105px;">
+                                    <button data-type="btn-modify" type="button" class="btn btn-outline-success m-0 " data-bs-toggle="popover" data-bs-placement="right" style="display:none; width:105px;">
                                         <span class="fa fa-pencil-alt mr-2" style="padding-right:5px"></span>Modify
                                     </button>
                                 </div>

--- a/AIS/AIS/Views/Shared/_Layout.cshtml
+++ b/AIS/AIS/Views/Shared/_Layout.cshtml
@@ -61,7 +61,7 @@
             <img src="~/Images/ztbllogo.png" width="35" height="35" class="d-inline-block align-top" alt="ZTBL" />
             <span class="ml-2 font-weight-bold">ZTBL Audit System</span>
         </a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navBarTopMenu" aria-controls="navBarTopMenu" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navBarTopMenu" aria-controls="navBarTopMenu" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
 
@@ -77,7 +77,7 @@
                             menu_name = item.Menu_Name;
                             <div class="dropdown">
 
-                                <button class="btn btn-default bg-transparent dropdown-toggle font-weight-bold" type="button" data-toggle="dropdown">@item.Menu_Name</button>
+                                <button class="btn btn-default bg-transparent dropdown-toggle font-weight-bold" type="button" data-bs-toggle="dropdown">@item.Menu_Name</button>
 
                                 @if (ViewData["TopMenuPages"] != null)
                                     {
@@ -153,7 +153,7 @@
                 <ul class="navbar-nav mt-2 mt-lg-0 ml-auto">
                     <!-- ml-auto will align items to the right -->
                     <li class="nav-item active dropdown">
-                        <a class="nav-link" href="#" id="navImg" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <a class="nav-link" href="#" id="navImg" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <small><b>Welcome:</b></small>
                             @if (ViewData["TopMenuPages"] != null)
                                 {


### PR DESCRIPTION
## Summary
- use Bootstrap 5 `data-bs-*` attributes
- remove extra `&times;` spans from modal close buttons

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e30f3410832ea084ee50d7a14487