### PR TITLE
Fix eng plan list columns

### DIFF
--- a/AIS/AIS/Views/Engagement/eng_plan_list.cshtml
+++ b/AIS/AIS/Views/Engagement/eng_plan_list.cshtml
@@ -96,7 +96,8 @@
                 <th>Operation End Date</th>
                 <th>Start Date</th>
                 <th>End Date</th>
-                <th>Action</th>
+                <th>Reject</th>
+                <th>Approve</th>
             </tr>
         </thead>
         <tbody>
@@ -120,7 +121,8 @@
                             <td class="col-md-auto">@oeDate</td>
                             <td class="col-md-auto">@sDate</td>
                             <td class="col-md-auto">@eDate</td>
-                            <td class="col-md-auto"><a onclick="referredBackEngagementPlan(@item.ENG_ID);" href="#" class="text-danger text-hover">Reject</a><a onclick="approveEngagementPlan(@item.ENG_ID);" href="#" class="text-success text-hover ml-5">Approve</a></td>
+                            <td class="col-md-auto"><a onclick="referredBackEngagementPlan(@item.ENG_ID);" href="#" class="text-danger text-hover">Reject</a></td>
+                            <td class="col-md-auto"><a onclick="approveEngagementPlan(@item.ENG_ID);" href="#" class="text-success text-hover ml-5">Approve</a></td>
                             
                         </tr>
 


### PR DESCRIPTION
## Summary
- separate approval and rejection actions into two columns on the engagement plan list view

## Testing
- `dotnet test AIS/AIS/AIS.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e88c1b60832eb1d1386e28551263