### PR TITLE
Fix auditee entity update workflow

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 
@@ -479,6 +480,11 @@ namespace AIS.Controllers
         public List<AuditeeEntitiesModel> GetAuditeeEntitiesByTypeId(int ENTITY_TYPE_ID = 0)
             {
             return dBConnection.GetAuditeeEntitiesForUpdate(ENTITY_TYPE_ID);
+            }
+        [HttpPost]
+        public AuditeeEntitiesModel GetAuditeeEntityById(int ENTITY_ID = 0)
+            {
+            return dBConnection.GetAuditeeEntitiesForUpdate(0, ENTITY_ID).FirstOrDefault();
             }
         [HttpPost]
         public List<AuditeeEntityUpdateModel> GetAuditeeEntitiesPendingAuthorization()

--- a/AIS/AIS/Views/AdministrationPanel/authorize_auditee_entities_update.cshtml
+++ b/AIS/AIS/Views/AdministrationPanel/authorize_auditee_entities_update.cshtml
@@ -4,6 +4,7 @@
 }
 <script type="text/javascript">
     var g_pending = [];
+    var g_current = null;
     function loadPending() {
         $('#pendingGrid tbody').empty();
         $.ajax({
@@ -13,39 +14,78 @@
             success: function (data) {
                 g_pending = data;
                 $.each(data, function (i, v) {
-                    $('#pendingGrid tbody').append('<tr><td>' + v.entitY_ID + '</td><td>' + v.code + '</td><td>' + v.name + '</td><td>' + v.active + '</td><td>' + v.auditbY_ID + '</td><td>' + v.auditable + '</td><td>' + v.address + '</td><td>' + v.telephone + '</td><td>' + v.emaiL_ADDRESS + '</td><td><a href="#" onclick="event.preventDefault();authorize(' + v.entity_id + ');" class="text-success">Authorize</a> | <a href="#" onclick="event.preventDefault();reject(' + v.entity_id + ');" class="text-danger">Reject</a></td></tr>');
+                    $('#pendingGrid tbody').append('<tr><td>' + v.entitY_ID + '</td><td>' + v.code + '</td><td>' + v.name + '</td><td>' + v.active + '</td><td>' + v.auditbY_ID + '</td><td>' + v.auditable + '</td><td>' + v.address + '</td><td>' + v.telephone + '</td><td>' + v.emaiL_ADDRESS + '</td><td><a href="#" onclick="event.preventDefault();openCompare(' + v.entity_id + ');" class="text-danger">View</a></td></tr>');
                 });
             },
             dataType: "json",
         });
     }
-    function authorize(id) {
+    function openCompare(id) {
         var ent = g_pending.find(e => e.ENTITY_ID == id);
         if (!ent) return;
-        ent.UP_STATUS = 'A';
+        g_current = ent;
+        $('#compareEntityId').val(id);
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/GetAuditeeEntityById",
+            type: "POST",
+            data: { ENTITY_ID: id },
+            cache: false,
+            success: function (orig) {
+                if (!orig) return;
+                $('#oldCode').val(orig.code);
+                $('#oldName').val(orig.name);
+                $('#oldActive').val(orig.active);
+                $('#oldAuditBy').val(orig.auditbY_ID);
+                $('#oldAuditable').val(orig.auditable);
+                $('#oldAddress').val(orig.address);
+                $('#oldTelephone').val(orig.telephone);
+                $('#oldEmail').val(orig.emaiL_ADDRESS);
+                $('#oldRisk').val(orig.risk_ID);
+                $('#oldSize').val(orig.size_ID);
+
+                $('#newCode').val(ent.code);
+                $('#newName').val(ent.name);
+                $('#newActive').val(ent.active);
+                $('#newAuditBy').val(ent.auditbY_ID);
+                $('#newAuditable').val(ent.auditable);
+                $('#newAddress').val(ent.address);
+                $('#newTelephone').val(ent.telephone);
+                $('#newEmail').val(ent.emaiL_ADDRESS);
+                $('#newRisk').val(ent.risk_ID);
+                $('#newSize').val(ent.size_ID);
+
+                $('#compareModal').modal('show');
+            },
+            dataType: "json",
+        });
+    }
+    function authorizeCurrent() {
+        if (!g_current) return;
+        g_current.UP_STATUS = 'A';
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/UpdateAuditeeEntity",
             type: "POST",
-            data: { ENTITY_MODEL: ent, IND: 'A' },
+            data: { ENTITY_MODEL: g_current, IND: 'A' },
             cache: false,
             success: function (resp) {
                 alert(resp.Message);
+                $('#compareModal').modal('hide');
                 loadPending();
             },
             dataType: "json",
         });
     }
-    function reject(id) {
-        var ent = g_pending.find(e => e.ENTITY_ID == id);
-        if (!ent) return;
-        ent.UP_STATUS = 'R';
+    function rejectCurrent() {
+        if (!g_current) return;
+        g_current.UP_STATUS = 'R';
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/UpdateAuditeeEntity",
             type: "POST",
-            data: { ENTITY_MODEL: ent, IND: 'R' },
+            data: { ENTITY_MODEL: g_current, IND: 'R' },
             cache: false,
             success: function (resp) {
                 alert(resp.Message);
+                $('#compareModal').modal('hide');
                 loadPending();
             },
             dataType: "json",
@@ -74,5 +114,54 @@
             </thead>
             <tbody></tbody>
         </table>
+</div>
+</div>
+<div id="compareModal" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-danger text-white">
+                <h5 class="modal-title">Audit Entity Update</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="hidden" id="compareEntityId" />
+                <div class="row">
+                    <div class="col-md-6">
+                        <form>
+                            <h6 class="text-center"><b>Existing Details</b></h6>
+                            <div class="form-group"><label>Code</label><input id="oldCode" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Name</label><input id="oldName" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Active</label><input id="oldActive" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Audit By</label><input id="oldAuditBy" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Auditable</label><input id="oldAuditable" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Address</label><input id="oldAddress" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Telephone</label><input id="oldTelephone" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Email</label><input id="oldEmail" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Risk</label><input id="oldRisk" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Size</label><input id="oldSize" disabled class="form-control" /></div>
+                        </form>
+                    </div>
+                    <div class="col-md-6">
+                        <form>
+                            <h6 class="text-center"><b>Proposed Changes</b></h6>
+                            <div class="form-group"><label>Code</label><input id="newCode" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Name</label><input id="newName" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Active</label><input id="newActive" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Audit By</label><input id="newAuditBy" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Auditable</label><input id="newAuditable" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Address</label><input id="newAddress" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Telephone</label><input id="newTelephone" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Email</label><input id="newEmail" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Risk</label><input id="newRisk" disabled class="form-control" /></div>
+                            <div class="form-group"><label>Size</label><input id="newSize" disabled class="form-control" /></div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-success" onclick="authorizeCurrent();">Authorize</button>
+                <button type="button" class="btn btn-danger" onclick="rejectCurrent();">Reject</button>
+            </div>
+        </div>
     </div>
 </div>

--- a/AIS/AIS/Views/AdministrationPanel/update_auditee_entities.cshtml
+++ b/AIS/AIS/Views/AdministrationPanel/update_auditee_entities.cshtml
@@ -39,8 +39,8 @@
         $('#modalAddress').val(getVal(ent, 'address'));
         $('#modalTelephone').val(getVal(ent, 'telephone'));
         $('#modalEmail').val(getVal(ent, 'emaiL_ADDRESS'));
-        $('#modalRisk').val(getVal(ent, 'risk_ID'));
-        $('#modalSize').val(getVal(ent, 'size_ID'));
+        $('#modalRisk').val(String(getVal(ent, 'risk_ID')));
+        $('#modalSize').val(String(getVal(ent, 'size_ID')));
         $('#updateEntityModal').modal('show');
     }
     function saveEntity() {


### PR DESCRIPTION
## Summary
- preselect Risk and Size when editing an entity
- expose new API `GetAuditeeEntityById`
- show comparison modal before authorizing auditee entity updates

## Testing
- `dotnet build AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552b880b60832eac0afa6e6f12fc89