### PR TITLE
Add email management views and UI refresh

### DIFF
--- a/AIS/AIS/Controllers/EmailController.cs
+++ b/AIS/AIS/Controllers/EmailController.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Hosting;
+using System.IO;
+using System.Threading;
+using AIS;
+
+namespace AIS.Controllers
+{
+    public class EmailController : Controller
+    {
+        private readonly IWebHostEnvironment _env;
+        private static Timer? _reminderTimer;
+        private readonly EmailConfiguration _emailConfig = new EmailConfiguration();
+
+        public EmailController(IWebHostEnvironment env)
+        {
+            _env = env;
+        }
+
+        public IActionResult Edit()
+        {
+            string templatePath = Path.Combine(_env.WebRootPath, "Templates", "GeneralNotification.html");
+            ViewBag.TemplateBody = System.IO.File.Exists(templatePath) ? System.IO.File.ReadAllText(templatePath) : string.Empty;
+            return View();
+        }
+
+        [HttpPost]
+        public IActionResult Edit(string body)
+        {
+            string templatePath = Path.Combine(_env.WebRootPath, "Templates", "GeneralNotification.html");
+            Directory.CreateDirectory(Path.GetDirectoryName(templatePath)!);
+            System.IO.File.WriteAllText(templatePath, body ?? string.Empty);
+            ViewBag.TemplateBody = body;
+            ViewBag.Message = "Template updated successfully.";
+            return View();
+        }
+
+        public IActionResult Send()
+        {
+            string templatePath = Path.Combine(_env.WebRootPath, "Templates", "GeneralNotification.html");
+            ViewBag.TemplateBody = System.IO.File.Exists(templatePath) ? System.IO.File.ReadAllText(templatePath) : string.Empty;
+            return View();
+        }
+
+        [HttpPost]
+        public IActionResult Send(string toEmail, string ccEmail, string subject, string body, int reminderMinutes = 0)
+        {
+            _emailConfig.ConfigEmail(toEmail, ccEmail, subject, body);
+
+            _reminderTimer?.Dispose();
+            if (reminderMinutes > 0)
+            {
+                _reminderTimer = new Timer(_ =>
+                {
+                    _emailConfig.ConfigEmail(toEmail, ccEmail, subject, body);
+                }, null, reminderMinutes * 60000, reminderMinutes * 60000);
+            }
+
+            ViewBag.Message = "Email Sent";
+            ViewBag.TemplateBody = body;
+            return View();
+        }
+    }
+}

--- a/AIS/AIS/Views/Email/Edit.cshtml
+++ b/AIS/AIS/Views/Email/Edit.cshtml
@@ -1,0 +1,17 @@
+@{
+    ViewData["Title"] = "Edit Email Template";
+}
+<div class="container mt-4">
+    <h3 class="mb-3">Edit Notification Template</h3>
+    @if (ViewBag.Message != null)
+    {
+        <div class="alert alert-success">@ViewBag.Message</div>
+    }
+    <form method="post">
+        <div class="mb-3">
+            <label class="form-label">Body</label>
+            <textarea name="body" class="form-control" rows="10">@ViewBag.TemplateBody</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>

--- a/AIS/AIS/Views/Email/Send.cshtml
+++ b/AIS/AIS/Views/Email/Send.cshtml
@@ -1,0 +1,33 @@
+@{
+    ViewData["Title"] = "Send Email";
+}
+<div class="container mt-4">
+    <h3 class="mb-3">Send Notification</h3>
+    @if (ViewBag.Message != null)
+    {
+        <div class="alert alert-success">@ViewBag.Message</div>
+    }
+    <form method="post">
+        <div class="mb-3">
+            <label class="form-label">To</label>
+            <input type="email" name="toEmail" class="form-control" required />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">CC</label>
+            <input type="email" name="ccEmail" class="form-control" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Subject</label>
+            <input type="text" name="subject" class="form-control" required />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Body</label>
+            <textarea name="body" class="form-control" rows="10">@ViewBag.TemplateBody</textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Auto Reminder (minutes)</label>
+            <input type="number" name="reminderMinutes" class="form-control" min="0" />
+        </div>
+        <button type="submit" class="btn btn-success">Send</button>
+    </form>
+</div>

--- a/AIS/AIS/Views/Login/index.cshtml
+++ b/AIS/AIS/Views/Login/index.cshtml
@@ -154,7 +154,7 @@
                             </div>
 
                             <!-- Submit button -->
-                            <button id="submitKillSessionButton" type="button" class="btn btn-block btn-danger mb-4 d-none" onclick="doKillSessionSubmit();">
+                            <button id="submitKillSessionButton" type="button" class="btn btn-block mb-4 kill-btn d-none" onclick="doKillSessionSubmit();">
                                 Kill Session
                             </button>
                             <button id="submitLoginButton" type="button" class="btn btn-block mb-4 login-btn" onclick="doLoginSubmit();">

--- a/AIS/AIS/wwwroot/Templates/GeneralNotification.html
+++ b/AIS/AIS/wwwroot/Templates/GeneralNotification.html
@@ -1,0 +1,3 @@
+<p>Dear Sir/Madam,</p>
+<p>This is a sample notification from IAS.</p>
+<p>Best Regards,<br/>Internal Audit System</p>

--- a/AIS/AIS/wwwroot/css/login.css
+++ b/AIS/AIS/wwwroot/css/login.css
@@ -22,6 +22,17 @@
     color: #fff;
 }
 
+.kill-btn {
+    background: #dc3545;
+    color: #fff;
+    transition: background-color .2s ease;
+}
+
+.kill-btn:hover {
+    background: #b52a37;
+    color: #fff;
+}
+
 .login-btn:hover {
     background: #3b49a1;
     color: #fff;

--- a/AIS/AIS/wwwroot/css/site.css
+++ b/AIS/AIS/wwwroot/css/site.css
@@ -1,5 +1,8 @@
 ﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 for details on configuring this project to bundle and minify static web assets. */
+body {
+    font-family: 'DejaVu Sans', sans-serif;
+}
 .container-clob {
     width: 100% !important;
     margin: 10px auto !important;
@@ -194,5 +197,15 @@ table.dataTable thead th {
 /* Color for top menu buttons */
 .navbar .btn-link {
     --bs-btn-color: #3a5681;
+}
+
+/* Rounded modals for cleaner look */
+.modal-content {
+    border-radius: 0.75rem;
+}
+
+/* Sleek card edges */
+.card {
+    border-radius: 0.75rem;
 }
 


### PR DESCRIPTION
## Summary
- freshen login page styling and use sleek fonts
- restyle site-wide UI elements with DejaVu Sans font and rounded components
- add EmailController for editing templates and sending emails
- add views to edit email templates and send email notifications
- include sample email template
- drop bundled Roboto font files to avoid binary patch issues

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d71958c4832e8232adc403157d02