### PR TITLE
Add color-coded risk display

### DIFF
--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -240,6 +240,15 @@
             }
         });
         $('#viewMemo_risk_display').val(riskName);
+        var color = '';
+        if (riskName.toLowerCase() === 'high') {
+            color = 'red';
+        } else if (riskName.toLowerCase() === 'medium') {
+            color = 'gold';
+        } else if (riskName.toLowerCase() === 'low') {
+            color = 'green';
+        }
+        $('#viewMemo_risk_display').css('color', color);
     }
 
     function openResponsiblePPs() {
@@ -474,6 +483,10 @@
 
         </select>
     </div>
+    <div class="col-md-12 mt-2">
+        <label for="viewMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
+        <input id="viewMemo_risk_display" class="form-control" readonly />
+    </div>
     <div class="col-md-12 mt-3">
         <div>
             <h5>Checklist</h5>
@@ -509,10 +522,6 @@
         <div class="page-wrapper box-content">
             <textarea id="template_box" class="content" name="example"></textarea>
         </div>
-    </div>
-    <div class="col-md-12 mt-3">
-        <h5>Risk</h5>
-        <input id="viewMemo_risk_display" class="form-control" readonly />
     </div>
     <div class="row col-sm-12">
         <div class="col-md-2 mt-3">

--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -99,6 +99,15 @@
             }
         });
         $('#viewMemo_risk_display').val(riskName);
+        var color = '';
+        if (riskName.toLowerCase() === 'high') {
+            color = 'red';
+        } else if (riskName.toLowerCase() === 'medium') {
+            color = 'gold';
+        } else if (riskName.toLowerCase() === 'low') {
+            color = 'green';
+        }
+        $('#viewMemo_risk_display').css('color', color);
     }
     function saveMemoContent() {
         if ($('#updatedAnnexlist').val() == 0) {
@@ -564,6 +573,10 @@
                         </div>
 
                     </div>
+                    <div class="form-group mt-2">
+                        <label for="viewMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
+                        <input id="viewMemo_risk_display" class="form-control" readonly />
+                    </div>
                     <div class="form-group">
                         <label for="viewMemo_memo">Heading/Title of Para</label>
                         <input id="viewMemo_heading" class="form-control" />
@@ -571,10 +584,6 @@
                     <div class="form-group">
                         <label for="viewMemo_memo">Memo</label>
                         <textarea id="viewMemo_memo" style="height:300px;" class="form-control"></textarea>
-                    </div>
-                    <div class="form-group">
-                        <label for="viewMemo_risk_display">Risk</label>
-                        <input id="viewMemo_risk_display" class="form-control" readonly />
                     </div>
 
                     <div class="form-group">


### PR DESCRIPTION
## Summary
- show risk field just after Annexure selection in checklist and CAU observation views
- display label "Risk will be assigned on the basis of Selected Annexure"
- color-code risk text for High/Medium/Low

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685902304a20832e9b0e8856e64bf1a1