### PR TITLE
Show maintenance page when DB fails

### DIFF
--- a/AIS/AIS/Controllers/LoginController.cs
+++ b/AIS/AIS/Controllers/LoginController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Diagnostics;
 
 namespace AIS.Controllers
@@ -40,27 +41,38 @@ namespace AIS.Controllers
             return RedirectToAction("Index", "Login");
             }
         [HttpPost]
-        public UserModel DoLogin(LoginModel login)
+        public IActionResult DoLogin(LoginModel login)
             {
-
-            var user = dBConnection.AutheticateLogin(login);
-            if (user.ID != 0 && !user.isAlreadyLoggedIn && user.isAuthenticate)
+            try
                 {
-                return user;
-                }
-            else
-                {
-                if (user.isAuthenticate && user.isAlreadyLoggedIn)
+                var user = dBConnection.AutheticateLogin(login);
+                if (user.ID != 0 && !user.isAlreadyLoggedIn && user.isAuthenticate)
                     {
-                    user.ErrorMsg = "You are already loggin in System";
-                    return user;
+                    return Json(user);
                     }
                 else
                     {
-                    user.ErrorMsg = "Incorrect UserName or Password";
-                    return user;
+                    if (user.isAuthenticate && user.isAlreadyLoggedIn)
+                        {
+                        user.ErrorMsg = "You are already loggin in System";
+                        }
+                    else
+                        {
+                        user.ErrorMsg = "Incorrect UserName or Password";
+                        }
+                    return Json(user);
                     }
                 }
+            catch (Exception ex)
+                {
+                _logger.LogError(ex, "Database error during login");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable);
+                }
+            }
+
+        public IActionResult Maintenance()
+            {
+            return View();
             }
 
         public string ResetPassword(string PPNumber, string CNICNumber)

--- a/AIS/AIS/Views/Login/Maintenance.cshtml
+++ b/AIS/AIS/Views/Login/Maintenance.cshtml
@@ -1,0 +1,21 @@
+@{
+    ViewData["Title"] = "System Maintenance";
+}
+
+<div class="text-center">
+    <section class="text-center">
+        <div class="p-5 bg-image bg-gradient" style=" height: 350px; background: linear-gradient(160deg, hsl(233deg 96% 29% / 95%), #a4a2a2bf);">
+            <img style="height: 126px;" src="~/Images/ztbllogo.png" />
+        </div>
+        <div class="card mx-4 mx-md-5 shadow-5-strong"  style=" margin-top: -100px; backdrop-filter: blur(20px); background: linear-gradient(292deg, #2257b8, #ef8691);">
+            <div class="card-body py-5 px-md-5">
+                <div class="row d-flex justify-content-center">
+                    <div class="col-lg-6">
+                        <h2 class="fw-bold mb-5" style="color:white">System is currently under maintenance.</h2>
+                        <p class="text-white">Please try again later.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/AIS/AIS/Views/Login/index.cshtml
+++ b/AIS/AIS/Views/Login/index.cshtml
@@ -108,6 +108,9 @@
                 $('#submitLoginButton').attr('disabled', false);
             },
             dataType: "json",
+            error: function () {
+                window.location.href = g_asiBaseURL + "/Login/Maintenance";
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- handle database connection failures during login
- add a Maintenance action and view
- redirect user to maintenance page from login when server returns error

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591372dc84832ebf3f5cd591089428