### PR TITLE
Add risk info and reject options

### DIFF
--- a/AIS/AIS/Views/Execution/Authorize_Change_Settle_Para_Status.cshtml
+++ b/AIS/AIS/Views/Execution/Authorize_Change_Settle_Para_Status.cshtml
@@ -5,10 +5,11 @@
 <script>
     var g_paraId = 0;
     var g_obsList = [];
-
+    
     var g_paraRef = 0;
     var g_paraObsId = 0;
     var g_ind = "";
+    var g_action = "A";
     $(document).ready(function () {
         getLegacyPara();
 
@@ -37,7 +38,7 @@
                 $.each(data, function (index, child) {
                     var status_text= child.parA_STATUS;
                     var status_change_text = child.parA_CHANGE_REQUEST_STATUS;
-                    $('#manageObsPanel tbody').append('<tr id="div_' + child.id + '"><td><p class="fw-normal mb-1">' + child.entitY_NAME + '</p></td><td><p class="fw-normal mb-1">' + child.audiT_PERIOD + '</p></td><td><p class="fw-normal mb-1">' + child.parA_NO + '</p></td><td><p class="fw-normal mb-1">' + child.gisT_OF_PARAS + '</p></td><td><p class="fw-normal mb-1">' + child.voL_I_II + '</p></td><td><p class="fw-normal mb-1">' + status_text + '</p></td><td><p class="fw-normal mb-1">' + status_change_text + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.remarks + '</p></td><td class="text-center"><a class="text-center text-danger" style="cursor:pointer;" onclick="event.preventDefault();parastatuschange(\'' + child.reF_P + '\',\'' + child.aU_OBS_ID + '\',\'' + child.ind + '\');">Authorize</a></td></tr>')
+                    $('#manageObsPanel tbody').append('<tr id="div_' + child.id + '"><td><p class="fw-normal mb-1">' + child.entitY_NAME + '</p></td><td><p class="fw-normal mb-1">' + child.audiT_PERIOD + '</p></td><td><p class="fw-normal mb-1">' + child.parA_NO + '</p></td><td><p class="fw-normal mb-1">' + child.gisT_OF_PARAS + '</p></td><td><p class="fw-normal mb-1">' + child.parA_RISK + '</p></td><td><p class="fw-normal mb-1">' + child.voL_I_II + '</p></td><td><p class="fw-normal mb-1">' + status_text + '</p></td><td><p class="fw-normal mb-1">' + status_change_text + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.remarks + '</p></td><td class="text-center"><a class="text-center text-primary" style="cursor:pointer;" onclick="event.preventDefault();paraText(\'' + child.reF_P + '\',\'' + child.aU_OBS_ID + '\');">Para Text</a></td><td class="text-center"><a class="text-danger" style="cursor:pointer;" onclick="event.preventDefault();parastatuschange(\'' + child.reF_P + '\',\'' + child.aU_OBS_ID + '\',\'A\');">Authorize</a> | <a class="text-danger" style="cursor:pointer;" onclick="event.preventDefault();rejectPara(\'' + child.reF_P + '\',\'' + child.aU_OBS_ID + '\');">Reject</a></td></tr>');
                 });
             },
 
@@ -46,13 +47,22 @@
 
     }
     function parastatuschange(refp, obsId, ind) {
-           
+
+        g_action = 'A';
         g_paraRef = refp;
         g_paraObsId = obsId;
         g_ind = ind;
         confirmAlert("Do you confirm to authorize this Para Status Change Request");
-        onconfirmAlertCallback(Publishchange);      
-        
+        onconfirmAlertCallback(Publishchange);
+
+    }
+
+    function rejectPara(refp, obsId) {
+        g_action = 'R';
+        g_paraRef = refp;
+        g_paraObsId = obsId;
+        confirmAlert("Do you confirm to reject this Para Status Change Request");
+        onconfirmAlertCallback(Publishchange);
     }
 
 
@@ -65,7 +75,7 @@
             data: {
                 'REFID': g_paraRef,
                 'OBS_ID': g_paraObsId,
-                'INDICATOR': g_ind              
+                'INDICATOR': g_action
             },
             cache: false,
             success: function (data) {
@@ -77,6 +87,24 @@
     }
     function reloadLocation() {
         getLegacyPara();
+    }
+
+    function paraText(refp, obsId) {
+        $('#paraTextDisplayModel').modal('show');
+        $('#paraTextModelPanel').empty();
+
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/get_new_para_text",
+            type: "POST",
+            data: {
+                'OBS_ID': obsId
+            },
+            cache: false,
+            success: function (data) {
+                $('#paraTextModelPanel').html(data);
+            }
+        });
+
     }
 
 </script>
@@ -93,10 +121,12 @@
                     <th class="col-md-auto">Audit Year</th>
                     <th class="col-md-auto">Para No.</th>
                     <th class="col-md-auto">Gist</th>
+                    <th class="col-md-auto">Risk</th>
                     <th class="col-md-auto">VOL I-II</th>
                     <th class="col-md-auto">Existing Status</th>
                     <th class="col-md-auto">New Status</th>
                     <th class="col-md-auto">Remarks</th>
+                    <th class="col-md-auto">Para Text</th>
                     <th class="col-md-auto">Action</th>
 
 
@@ -105,7 +135,35 @@
             <tbody></tbody>
           
         </table>
-    </div>
+</div>
 
+</div>
+
+<div id="paraTextDisplayModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog  modal-xl" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-danger text-white">
+                <h5 class="modal-title">Para Text</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close">
+
+                </button>
+            </div>
+            <div class="mt-3 modal-body">
+                <form>
+
+                    <div class="mt-2 col-md-12">
+                        <div id="paraTextModelPanel"></div>
+
+                    </div>
+
+
+                </form>
+            </div>
+
+            <div class="mt-3 modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
 </div>
 

--- a/AIS/AIS/Views/HM/old_paras_monitoring.cshtml
+++ b/AIS/AIS/Views/HM/old_paras_monitoring.cshtml
@@ -45,7 +45,7 @@
                 cache: false,
                 success: function (data) {
                     $.each(data, function (i, v) {
-                        $('#manageObsPanel tbody').append('<tr id="assignedObRow_' + v.id + '"><td>' + ++i + '</td><td>' + v.entitY_NAME + '</td><td>' + v.audiT_PERIOD + '</td><td>' + v.memO_NO + '</td><td>' + v.gisT_OF_PARAS + '</td><td><a hre="#" class="text-danger text-center" style="cursor:pointer;" onclick="event.preventDefault();viewParaText(\'' + v.parA_ID + '\',\'' + v.obS_ID + '\',\'' + v.parA_CATEGORY + '\')"> View Para</a></td></tr>');
+                        $('#manageObsPanel tbody').append('<tr id="assignedObRow_' + v.id + '"><td>' + ++i + '</td><td>' + v.entitY_NAME + '</td><td>' + v.audiT_PERIOD + '</td><td>' + v.memO_NO + '</td><td>' + v.parA_RISK + '</td><td>' + v.gisT_OF_PARAS + '</td><td><a hre="#" class="text-danger text-center" style="cursor:pointer;" onclick="event.preventDefault();viewParaText(\'' + v.parA_ID + '\',\'' + v.obS_ID + '\',\'' + v.parA_CATEGORY + '\')"> View Para</a></td></tr>');
 
                     });
                     initializeDataTable('manageObsPanel');
@@ -119,6 +119,7 @@
                 <th class="col-md-2">Entity Name</th>
                 <th class="col-md-1">Audit Year</th>
                 <th class="col-md-1">Para Number</th>
+                <th class="col-md-1">Risk</th>
                 <th class="col-md-5">Heading</th>
                 <th class="col-md-2 text-center"></th>
             </tr>

--- a/AIS/AIS/Views/PostCompliance/change_status_new_Para_authorize.cshtml
+++ b/AIS/AIS/Views/PostCompliance/change_status_new_Para_authorize.cshtml
@@ -6,6 +6,7 @@
     var g_paraId = 0;
     var refp = 0;
     var g_obsList = [];
+    var g_action = "A";
 
     $(document).ready(function () {
         getLegacyPara();
@@ -25,7 +26,7 @@
                 g_obsList = data;
 
                 $.each(data, function (index, child) {
-                    $('#manageObsPanel tbody').append('<tr id="div_' + child.id + '"><td><p class="fw-normal mb-1">' + child.entitY_NAME + '</p></td><td><p class="fw-normal mb-1">' + child.audiT_PERIOD + '</p></td><td><p class="fw-normal mb-1">' + child.parA_NO + '</p></td><td><p class="fw-normal mb-1">' + child.gisT_OF_PARAS + '</p></td><td><p class="fw-normal mb-1">' + child.amounT_INVOLVED + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.parA_STATUS + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.makeR_REMARKS + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.revieweR_REMARKS + '</p></td><td class="text-center"><a class="text-center text-primary" style="cursor:pointer;" onclick="event.preventDefault();paraText(\'' + child.id + '\');">View Para Text</a></td><td><a class="text-danger" style="cursor:pointer;" onclick="parastatuschange(\'' + child.id + '\');">Authorize Status Change Request</a></td></tr>')
+                    $('#manageObsPanel tbody').append('<tr id="div_' + child.id + '"><td><p class="fw-normal mb-1">' + child.entitY_NAME + '</p></td><td><p class="fw-normal mb-1">' + child.audiT_PERIOD + '</p></td><td><p class="fw-normal mb-1">' + child.parA_NO + '</p></td><td><p class="fw-normal mb-1">' + child.gisT_OF_PARAS + '</p></td><td><p class="fw-normal mb-1">' + child.amounT_INVOLVED + '</p></td><td><p class="fw-normal mb-1">' + child.parA_RISK + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.parA_STATUS + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.makeR_REMARKS + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.revieweR_REMARKS + '</p></td><td class="text-center"><a class="text-center text-primary" style="cursor:pointer;" onclick="event.preventDefault();paraText(\'' + child.id + '\');">View Para Text</a></td><td><a class="text-danger" style="cursor:pointer;" onclick="parastatuschange(\'' + child.id + '\');">Authorize</a> | <a class="text-danger" style="cursor:pointer;" onclick="rejectPara(\'' + child.id + '\');">Reject</a></td></tr>');
                 });
 
             },
@@ -35,6 +36,13 @@
 
     }
     function parastatuschange(id) {
+        g_action = 'A';
+        refp = id;
+        $('#process_detail').modal('show');
+    }
+
+    function rejectPara(id) {
+        g_action = 'R';
         refp = id;
         $('#process_detail').modal('show');
     }
@@ -50,7 +58,8 @@
             type: "POST",
             data: {
                 'REFID': refp,
-                'REMARKS': $('#Reason_Unsettle').val()
+                'REMARKS': $('#Reason_Unsettle').val(),
+                'INDICATOR': g_action
             },
             cache: false,
             success: function (data) {
@@ -99,6 +108,7 @@
                     <th class="col-md-auto">Para No.</th>
                     <th class="col-md-auto">Observation</th>
                     <th class="col-md-auto">Amount</th>
+                    <th class="col-md-auto">Risk</th>
                     <th class="col-md-auto">Para Status</th>
                     <th class="col-md-auto">Maker Remarks</th>
                     <th class="col-md-auto">Reviewer Remarks</th>

--- a/AIS/AIS/Views/PostCompliance/change_status_new_Para_reviewer.cshtml
+++ b/AIS/AIS/Views/PostCompliance/change_status_new_Para_reviewer.cshtml
@@ -6,6 +6,7 @@
     var g_paraId = 0;
     var refp = 0;
     var g_obsList = [];
+    var g_action = "A";
 
     $(document).ready(function () {
         getLegacyPara();
@@ -25,7 +26,7 @@
                 g_obsList = data;
 
                 $.each(data, function (index, child) {
-                    $('#manageObsPanel tbody').append('<tr id="div_' + child.id + '"><td><p class="fw-normal mb-1">' + child.entitY_NAME + '</p></td><td><p class="fw-normal mb-1">' + child.audiT_PERIOD + '</p></td><td><p class="fw-normal mb-1">' + child.parA_NO + '</p></td><td><p class="fw-normal mb-1">' + child.gisT_OF_PARAS + '</p></td><td><p class="fw-normal mb-1">' + child.amounT_INVOLVED + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.parA_STATUS + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.makeR_REMARKS + '</p></td><td class="text-center"><a class="text-center text-primary" style="cursor:pointer;" onclick="event.preventDefault();paraText(\'' + child.id + '\');">View Para Text</a></td><td><a class="text-danger" style="cursor:pointer;" onclick="parastatuschange(\'' + child.id + '\');">Recommend Status Change Request</a></td></tr>')
+                    $('#manageObsPanel tbody').append('<tr id="div_' + child.id + '"><td><p class="fw-normal mb-1">' + child.entitY_NAME + '</p></td><td><p class="fw-normal mb-1">' + child.audiT_PERIOD + '</p></td><td><p class="fw-normal mb-1">' + child.parA_NO + '</p></td><td><p class="fw-normal mb-1">' + child.gisT_OF_PARAS + '</p></td><td><p class="fw-normal mb-1">' + child.amounT_INVOLVED + '</p></td><td><p class="fw-normal mb-1">' + child.parA_RISK + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.parA_STATUS + '</p></td><td class="col-md-1"><p  class="fw-normal mb-1" >' + child.makeR_REMARKS + '</p></td><td class="text-center"><a class="text-center text-primary" style="cursor:pointer;" onclick="event.preventDefault();paraText(\'' + child.id + '\');">View Para Text</a></td><td><a class="text-danger" style="cursor:pointer;" onclick="parastatuschange(\'' + child.id + '\');">Recommend</a> | <a class="text-danger" style="cursor:pointer;" onclick="rejectPara(\'' + child.id + '\');">Reject</a></td></tr>');
                 });
 
             },
@@ -35,6 +36,13 @@
 
     }
     function parastatuschange(id) {
+        g_action = 'A';
+        refp = id;
+        $('#process_detail').modal('show');
+    }
+
+    function rejectPara(id) {
+        g_action = 'R';
         refp = id;
         $('#process_detail').modal('show');
     }
@@ -50,7 +58,8 @@
             type: "POST",
             data: {
                 'REFID': refp,
-                'REMARKS': $('#Reason_Unsettle').val()
+                'REMARKS': $('#Reason_Unsettle').val(),
+                'INDICATOR': g_action
             },
             cache: false,
             success: function (data) {
@@ -101,6 +110,7 @@
                     <th class="col-md-auto">Para No.</th>
                     <th class="col-md-auto">Observation</th>
                     <th class="col-md-auto">Amount</th>
+                    <th class="col-md-auto">Risk</th>
                     <th class="col-md-auto">Para Status</th>
                     <th class="col-md-3">Maker Remarks</th>
                     <th class="col-md-auto">Para Text</th>


### PR DESCRIPTION
## Summary
- enable reject action for status change views
- add Risk column in various views
- allow viewing para text on authorize page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859136363a4832e976afcb388f15af3