### PR TITLE
Implement cache disabling for hard refresh

### DIFF
--- a/AIS/AIS/Startup.cs
+++ b/AIS/AIS/Startup.cs
@@ -65,6 +65,15 @@ namespace AIS
                 app.UseHsts();
                 }
             app.UseHttpsRedirection();
+
+            // Disable client-side caching to mimic a hard refresh on every load
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+                context.Response.Headers["Pragma"] = "no-cache";
+                context.Response.Headers["Expires"] = "0";
+                await next();
+            });
             app.UseStaticFiles();
             app.UseSession();
             app.UseRouting();


### PR DESCRIPTION
## Summary
- globally disable client-side caching so every request behaves like a hard refresh

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a304aec90832e84881c9d3a85de21