### PR TITLE
Add ViewHistory page

### DIFF
--- a/AIS/AIS/Controllers/Compliance/SBPComplianceController.cs
+++ b/AIS/AIS/Controllers/Compliance/SBPComplianceController.cs
@@ -36,6 +36,7 @@ namespace AIS.Controllers.Compliance
         {
             ViewData["TopMenu"] = tm.GetTopMenus();
             ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            ViewData["DivisionList"] = dBConnection.GetDivisions(false);
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
@@ -129,6 +130,18 @@ namespace AIS.Controllers.Compliance
 
             dBConnection.ProcessSBPAuditValidation(model.ObservationId, model.Action, model.Remarks);
             return RedirectToAction("ReviewHistory");
+        }
+        [HttpGet("Complaince/SBPCompliance/ViewHistory/{observationId}")]
+        public IActionResult ViewHistory(int observationId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            var history = dBConnection.GetSBPReviewHistory(observationId);
+            return View("../Complaince/SBPCompliance/ViewHistory", history);
+        }
+
         }
     }
 }

--- a/AIS/AIS/Views/Complaince/AddObservation.cshtml
+++ b/AIS/AIS/Views/Complaince/AddObservation.cshtml
@@ -4,7 +4,7 @@
 }
 <h4>Add SBP Observation</h4>
 <p>This screen allows Compliance &amp; ICFR Division to record SBP observations and assign them to a division.</p>
-<form>
+<form id="addObservationForm" enctype="multipart/form-data">
     <div class="form-group">
         <label for="observation">Observation</label>
         <textarea class="form-control" id="observation" rows="3"></textarea>
@@ -12,8 +12,71 @@
     <div class="form-group">
         <label for="division">Assign to Division</label>
         <select class="form-control" id="division">
-            <option>-- Select Division --</option>
+            <option value="">-- Select Division --</option>
+            @{
+                if (ViewData["DivisionList"] != null)
+                {
+                    foreach (var item in (dynamic)ViewData["DivisionList"])
+                    {
+                        <option value="@item.DIVISIONID">@item.NAME</option>
+                    }
+                }
+            }
         </select>
+    </div>
+    <div class="form-group">
+        <label for="attachment">Attachment</label>
+        <input type="file" class="form-control" id="attachment" />
     </div>
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>
+
+<script type="text/javascript">
+    $(document).ready(function () {
+        $('#addObservationForm').on('submit', function (e) {
+            e.preventDefault();
+
+            var obs = $('#observation').val();
+            var divId = $('#division').val();
+            var files = $('#attachment')[0].files;
+
+            if (files.length > 0) {
+                var fd = new FormData();
+                for (var i = 0; i < files.length; i++) {
+                    fd.append('files', files[i]);
+                }
+                $.ajax({
+                    url: g_asiBaseURL + '/ApiCalls/upload_post_compliance_evidences',
+                    type: 'POST',
+                    data: fd,
+                    processData: false,
+                    contentType: false,
+                    success: function () {
+                        var path = 'Audit_Evidences/' + files[0].name;
+                        addObservation(obs, divId, path);
+                    }
+                });
+            } else {
+                addObservation(obs, divId, '');
+            }
+        });
+
+        function addObservation(obs, divId, path) {
+            $.ajax({
+                url: g_asiBaseURL + '/ApiCalls/sbp_add_observation',
+                type: 'POST',
+                data: {
+                    'observation_text': obs,
+                    'division_id': divId,
+                    'attachment_path': path
+                },
+                success: function (data) {
+                    alert('Observation Added. ID: ' + data);
+                    $('#observation').val('');
+                    $('#division').val('');
+                    $('#attachment').val('');
+                }
+            });
+        }
+    });
+</script>

--- a/AIS/AIS/Views/Complaince/ViewHistory.cshtml
+++ b/AIS/AIS/Views/Complaince/ViewHistory.cshtml
@@ -1,0 +1,37 @@
+@model List<AIS.Models.SBPReviewHistory>
+@{
+    ViewData["Title"] = "View History";
+    Layout = "_Layout";
+}
+<h4>Observation History</h4>
+<table id="historyTable" class="table table-bordered table-striped">
+    <thead>
+        <tr>
+            <th>Reviewer Role</th>
+            <th>Reviewer Id</th>
+            <th>Comments</th>
+            <th>Action</th>
+            <th>Reviewed On</th>
+        </tr>
+    </thead>
+    <tbody>
+    @if (Model != null)
+    {
+        foreach (var item in Model)
+        {
+            <tr>
+                <td>@item.REVIEWER_ROLE</td>
+                <td>@item.REVIEWER_ID</td>
+                <td>@item.COMMENTS</td>
+                <td>@item.ACTION</td>
+                <td>@item.REVIEWED_ON.ToString("yyyy-MM-dd")</td>
+            </tr>
+        }
+    }
+    </tbody>
+</table>
+<script>
+    $(document).ready(function(){
+        initializeDataTable('historyTable');
+    });
+</script>

--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ The `ApiCallsController` exposes an `sbp_audit_validation` endpoint which wraps
 the `ProcessSBPAuditValidation` method in `DBConnection`. This endpoint accepts
 the observation id, action and remarks so that the Internal Audit team can
 validate, refer back or raise queries on an observation.
+
+The new `ViewHistory` page displays the review timeline for each observation.
+
+The `AddObservation` screen now submits data through the `sbp_add_observation`
+API endpoint, which in turn calls `DBConnection.AddSBPObservation` to execute
+the `PKG_T_AU_SBP_COMPLIANCE.ADD_OBSERVATION` stored procedure.


### PR DESCRIPTION
## Summary
- add a new ViewHistory page for SBP compliance
- expose a `ViewHistory` action in `SBPComplianceController`
- document the history view in README
- populate divisions on AddObservation page and wire it to `sbp_add_observation`

## Testing
- `dotnet` command not available, so build not run

------
https://chatgpt.com/codex/tasks/task_e_685c0fc1ec74832ebec165e87e7a697a