### PR TITLE
Implement FAD manpower budgeting scaffolding

### DIFF
--- a/AIS/AIS/Controllers/ManpowerDemandController.cs
+++ b/AIS/AIS/Controllers/ManpowerDemandController.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using AIS.Models;
+
+namespace AIS.Controllers
+{
+    public class ManpowerDemandController : Controller
+    {
+        private readonly DBContext _context;
+
+        public ManpowerDemandController(DBContext context)
+        {
+            _context = context;
+        }
+
+        public IActionResult Index()
+        {
+            var list = _context.ManpowerDemands.ToList();
+            return View("~/Views/FAD/ManpowerDemandIndex.cshtml", list);
+        }
+
+        public IActionResult Create()
+        {
+            var model = new ManpowerDemand { SubmittedOn = System.DateTime.Now };
+            return View("~/Views/FAD/ManpowerDemandCreate.cshtml", model);
+        }
+
+        [HttpPost]
+        public IActionResult Create(ManpowerDemand model)
+        {
+            if(ModelState.IsValid)
+            {
+                model.SubmittedOn = System.DateTime.Now;
+                _context.ManpowerDemands.Add(model);
+                _context.SaveChanges();
+                return RedirectToAction("Index");
+            }
+            return View("~/Views/FAD/ManpowerDemandCreate.cshtml", model);
+        }
+
+        public IActionResult Review(int id)
+        {
+            var demand = _context.ManpowerDemands.FirstOrDefault(m => m.Id == id);
+            if(demand == null) return NotFound();
+            return View("~/Views/FAD/ManpowerDemandReview.cshtml", demand);
+        }
+
+        [HttpPost]
+        public IActionResult Review(ManpowerDemand model)
+        {
+            if(ModelState.IsValid)
+            {
+                model.LastUpdatedOn = System.DateTime.Now;
+                _context.ManpowerDemands.Update(model);
+                _context.SaveChanges();
+                return RedirectToAction("Index");
+            }
+            return View("~/Views/FAD/ManpowerDemandReview.cshtml", model);
+        }
+    }
+}

--- a/AIS/AIS/Controllers/StaffPositionController.cs
+++ b/AIS/AIS/Controllers/StaffPositionController.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using AIS.Models;
+
+namespace AIS.Controllers
+{
+    public class StaffPositionController : Controller
+    {
+        private readonly DBContext _context;
+
+        public StaffPositionController(DBContext context)
+        {
+            _context = context;
+        }
+
+        public IActionResult Index()
+        {
+            var list = _context.StaffPositions.ToList();
+            return View("~/Views/FAD/StaffPositionIndex.cshtml", list);
+        }
+
+        public IActionResult Create()
+        {
+            return View("~/Views/FAD/StaffPositionCreate.cshtml");
+        }
+
+        [HttpPost]
+        public IActionResult Create(StaffPosition model)
+        {
+            if(ModelState.IsValid)
+            {
+                _context.StaffPositions.Add(model);
+                _context.SaveChanges();
+                return RedirectToAction("Index");
+            }
+            return View("~/Views/FAD/StaffPositionCreate.cshtml", model);
+        }
+    }
+}

--- a/AIS/AIS/Models/DBContext.cs
+++ b/AIS/AIS/Models/DBContext.cs
@@ -12,6 +12,8 @@ namespace AIS.Models
             Database.EnsureCreated();
             }
         public DbSet<UserModel> userModels { get; set; }
+        public DbSet<StaffPosition> StaffPositions { get; set; }
+        public DbSet<ManpowerDemand> ManpowerDemands { get; set; }
 
         }
     }

--- a/AIS/AIS/Models/ManpowerDemand.cs
+++ b/AIS/AIS/Models/ManpowerDemand.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace AIS.Models
+{
+    /// <summary>
+    /// Represents a manpower demand raised by an audit zone.
+    /// </summary>
+    public class ManpowerDemand
+    {
+        public int Id { get; set; }
+        public string Rank { get; set; }
+        public string Placement { get; set; }
+        public int Existing { get; set; }
+        public int AdditionalRequired { get; set; }
+        public int ZoneId { get; set; }
+        public string Status { get; set; }
+        public int SubmittedBy { get; set; }
+        public DateTime SubmittedOn { get; set; }
+        public int? LastUpdatedBy { get; set; }
+        public DateTime? LastUpdatedOn { get; set; }
+        public string HeadFadRemarks { get; set; }
+    }
+}

--- a/AIS/AIS/Models/StaffPosition.cs
+++ b/AIS/AIS/Models/StaffPosition.cs
@@ -1,0 +1,24 @@
+namespace AIS.Models
+{
+    /// <summary>
+    /// Represents a staff member position within the audit department.
+    /// These fields map directly to the Oracle table T_AU_STAFF_POSITION
+    /// and the PKG_HR package procedures.
+    /// </summary>
+    public class StaffPosition
+    {
+        public int Id { get; set; }
+        public string PPNO { get; set; }
+        public string Name { get; set; }
+        public string Rank { get; set; }
+        public string Designation { get; set; }
+        public string Placement { get; set; }
+        public string HighestQualification { get; set; }
+        public string Specialization { get; set; }
+        public string AuditCertification { get; set; }
+        public decimal TotalExperience { get; set; }
+        public decimal AuditExperience { get; set; }
+        public int ZoneId { get; set; }
+        public string Company { get; set; }
+    }
+}

--- a/AIS/AIS/Services/HrService.cs
+++ b/AIS/AIS/Services/HrService.cs
@@ -1,0 +1,89 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Oracle.ManagedDataAccess.Client;
+using System.Data;
+using AIS.Models;
+
+namespace AIS.Services
+{
+    /// <summary>
+    /// Simple wrapper around PKG_HR stored procedures.
+    /// Only minimal methods are implemented for demo purposes.
+    /// </summary>
+    public class HrService
+    {
+        private readonly IConfiguration _configuration;
+
+        public HrService(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        private OracleConnection CreateConnection()
+        {
+            var builder = new OracleConnectionStringBuilder
+            {
+                UserID = _configuration["ConnectionStrings:DBUserName"],
+                Password = _configuration["ConnectionStrings:DBUserPassword"],
+                DataSource = _configuration["ConnectionStrings:DBDataSource"],
+                Pooling = true
+            };
+            return new OracleConnection(builder.ConnectionString);
+        }
+
+        public void AddStaffPosition(StaffPosition model, int createdBy)
+        {
+            using var con = CreateConnection();
+            con.Open();
+            using var cmd = con.CreateCommand();
+            cmd.CommandText = "PKG_HR.ADD_STAFF_POSITION";
+            cmd.CommandType = CommandType.StoredProcedure;
+            cmd.Parameters.Add("P_PPNO", OracleDbType.Varchar2).Value = model.PPNO;
+            cmd.Parameters.Add("P_NAME", OracleDbType.Varchar2).Value = model.Name;
+            cmd.Parameters.Add("P_RANK", OracleDbType.Varchar2).Value = model.Rank;
+            cmd.Parameters.Add("P_DESIGNATION", OracleDbType.Varchar2).Value = model.Designation;
+            cmd.Parameters.Add("P_PLACEMENT", OracleDbType.Varchar2).Value = model.Placement;
+            cmd.Parameters.Add("P_HIGHEST_QUAL", OracleDbType.Varchar2).Value = model.HighestQualification;
+            cmd.Parameters.Add("P_SPECIALIZATION", OracleDbType.Varchar2).Value = model.Specialization;
+            cmd.Parameters.Add("P_AUDIT_CERT", OracleDbType.Varchar2).Value = model.AuditCertification;
+            cmd.Parameters.Add("P_TOT_EXPERIENCE", OracleDbType.Decimal).Value = model.TotalExperience;
+            cmd.Parameters.Add("P_AUDIT_EXPERIENCE", OracleDbType.Decimal).Value = model.AuditExperience;
+            cmd.Parameters.Add("P_ZONE_ID", OracleDbType.Int32).Value = model.ZoneId;
+            cmd.Parameters.Add("P_COMPANY", OracleDbType.Varchar2).Value = model.Company;
+            cmd.Parameters.Add("P_CREATED_BY", OracleDbType.Int32).Value = createdBy;
+            cmd.ExecuteNonQuery();
+        }
+
+        public void AddManpowerDemand(ManpowerDemand model)
+        {
+            using var con = CreateConnection();
+            con.Open();
+            using var cmd = con.CreateCommand();
+            cmd.CommandText = "PKG_HR.ADD_MANPOWER_DEMAND";
+            cmd.CommandType = CommandType.StoredProcedure;
+            cmd.Parameters.Add("P_STAFF_POSITION_ID", OracleDbType.Int32).Value = model.Id;
+            cmd.Parameters.Add("P_RANK", OracleDbType.Varchar2).Value = model.Rank;
+            cmd.Parameters.Add("P_PLACEMENT", OracleDbType.Varchar2).Value = model.Placement;
+            cmd.Parameters.Add("P_EXISTING", OracleDbType.Int32).Value = model.Existing;
+            cmd.Parameters.Add("P_ADDITIONAL_REQ", OracleDbType.Int32).Value = model.AdditionalRequired;
+            cmd.Parameters.Add("P_ZONE_ID", OracleDbType.Int32).Value = model.ZoneId;
+            cmd.Parameters.Add("P_STATUS", OracleDbType.Varchar2).Value = model.Status;
+            cmd.Parameters.Add("P_SUBMITTED_BY", OracleDbType.Int32).Value = model.SubmittedBy;
+            cmd.ExecuteNonQuery();
+        }
+
+        public void UpdateDemandStatus(int id, string status, int updatedBy, string remarks)
+        {
+            using var con = CreateConnection();
+            con.Open();
+            using var cmd = con.CreateCommand();
+            cmd.CommandText = "PKG_HR.UPDATE_MANPOWER_DEMAND_STATUS";
+            cmd.CommandType = CommandType.StoredProcedure;
+            cmd.Parameters.Add("P_ID", OracleDbType.Int32).Value = id;
+            cmd.Parameters.Add("P_STATUS", OracleDbType.Varchar2).Value = status;
+            cmd.Parameters.Add("P_UPDATED_BY", OracleDbType.Int32).Value = updatedBy;
+            cmd.Parameters.Add("P_REMARKS", OracleDbType.Varchar2).Value = remarks;
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/AIS/AIS/Startup.cs
+++ b/AIS/AIS/Startup.cs
@@ -4,9 +4,11 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using AIS.Models;
 using System;
 
 namespace AIS
@@ -31,6 +33,9 @@ namespace AIS
             services.AddScoped<SessionHandler>();
             services.AddScoped<DBConnection>();
             services.AddScoped<TopMenus>();
+            services.AddScoped<AIS.Services.HrService>();
+            services.AddDbContext<DBContext>(options =>
+                options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
             services.AddControllersWithViews().AddRazorRuntimeCompilation();
             services.AddHttpContextAccessor();
 

--- a/AIS/AIS/Views/FAD/ManpowerDemandCreate.cshtml
+++ b/AIS/AIS/Views/FAD/ManpowerDemandCreate.cshtml
@@ -1,0 +1,29 @@
+@model AIS.Models.ManpowerDemand
+@{
+    ViewData["Title"] = "Create Demand";
+    Layout = "_Layout";
+}
+<h3 class="mt-3" style="display:block;color:#45c545;">@ViewData["Title"]</h3>
+<form asp-action="Create" method="post" class="mt-3">
+    <div class="mb-2">
+        <label class="form-label">Rank</label>
+        <input asp-for="Rank" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Placement</label>
+        <input asp-for="Placement" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Existing Strength</label>
+        <input asp-for="Existing" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Additional Required</label>
+        <input asp-for="AdditionalRequired" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Zone Id</label>
+        <input asp-for="ZoneId" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-danger">Submit</button>
+</form>

--- a/AIS/AIS/Views/FAD/ManpowerDemandIndex.cshtml
+++ b/AIS/AIS/Views/FAD/ManpowerDemandIndex.cshtml
@@ -1,0 +1,35 @@
+@model IEnumerable<AIS.Models.ManpowerDemand>
+@{
+    ViewData["Title"] = "Manpower Demands";
+    Layout = "_Layout";
+}
+<h3 class="mt-3" style="display:block;color:#45c545;">@ViewData["Title"]</h3>
+<p>
+    <a class="btn btn-danger" asp-action="Create">Add New Demand</a>
+</p>
+<table class="table table-bordered table-striped bg-white">
+    <thead class="table-success">
+        <tr>
+            <th>Rank</th>
+            <th>Placement</th>
+            <th>Existing</th>
+            <th>Additional Required</th>
+            <th>Status</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach(var item in Model){
+        <tr>
+            <td>@item.Rank</td>
+            <td>@item.Placement</td>
+            <td>@item.Existing</td>
+            <td>@item.AdditionalRequired</td>
+            <td>@item.Status</td>
+            <td>
+                <a asp-action="Review" asp-route-id="@item.Id" class="btn btn-sm btn-primary">Review</a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/AIS/AIS/Views/FAD/ManpowerDemandReview.cshtml
+++ b/AIS/AIS/Views/FAD/ManpowerDemandReview.cshtml
@@ -1,0 +1,34 @@
+@model AIS.Models.ManpowerDemand
+@{
+    ViewData["Title"] = "Review Demand";
+    Layout = "_Layout";
+}
+<h3 class="mt-3" style="display:block;color:#45c545;">@ViewData["Title"]</h3>
+<form asp-action="Review" method="post" class="mt-3">
+    <input type="hidden" asp-for="Id" />
+    <div class="mb-2">
+        <label class="form-label">Rank</label>
+        <input asp-for="Rank" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Placement</label>
+        <input asp-for="Placement" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Existing</label>
+        <input asp-for="Existing" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Additional Required</label>
+        <input asp-for="AdditionalRequired" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Status</label>
+        <input asp-for="Status" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Head FAD Remarks</label>
+        <textarea asp-for="HeadFadRemarks" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-danger">Save</button>
+</form>

--- a/AIS/AIS/Views/FAD/StaffPositionCreate.cshtml
+++ b/AIS/AIS/Views/FAD/StaffPositionCreate.cshtml
@@ -1,0 +1,57 @@
+@model AIS.Models.StaffPosition
+@{
+    ViewData["Title"] = "Add Staff Position";
+    Layout = "_Layout";
+}
+<h3 class="mt-3" style="display:block;color:#45c545;">@ViewData["Title"]</h3>
+<form asp-action="Create" method="post" class="mt-3">
+    <div class="mb-2">
+        <label class="form-label">PPNO</label>
+        <input asp-for="PPNO" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Name</label>
+        <input asp-for="Name" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Rank</label>
+        <input asp-for="Rank" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Designation</label>
+        <input asp-for="Designation" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Placement</label>
+        <input asp-for="Placement" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Highest Qualification</label>
+        <input asp-for="HighestQualification" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Specialization</label>
+        <input asp-for="Specialization" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Audit Certification</label>
+        <input asp-for="AuditCertification" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Total Experience</label>
+        <input asp-for="TotalExperience" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Audit Experience</label>
+        <input asp-for="AuditExperience" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Zone Id</label>
+        <input asp-for="ZoneId" class="form-control" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Company</label>
+        <input asp-for="Company" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-danger">Save</button>
+</form>

--- a/AIS/AIS/Views/FAD/StaffPositionIndex.cshtml
+++ b/AIS/AIS/Views/FAD/StaffPositionIndex.cshtml
@@ -1,0 +1,33 @@
+@model IEnumerable<AIS.Models.StaffPosition>
+@{
+    ViewData["Title"] = "Staff Positions";
+    Layout = "_Layout";
+}
+<h3 class="mt-3" style="display:block;color:#45c545;">@ViewData["Title"]</h3>
+<p>
+    <a class="btn btn-danger" asp-action="Create">Add New</a>
+</p>
+<table class="table table-bordered table-striped bg-white">
+    <thead class="table-success">
+        <tr>
+            <th>PPNO</th>
+            <th>Name</th>
+            <th>Rank</th>
+            <th>Designation</th>
+            <th>Placement</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach(var item in Model){
+        <tr>
+            <td>@item.PPNO</td>
+            <td>@item.Name</td>
+            <td>@item.Rank</td>
+            <td>@item.Designation</td>
+            <td>@item.Placement</td>
+            <td></td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/AIS/AIS/appsettings.json
+++ b/AIS/AIS/appsettings.json
@@ -10,7 +10,8 @@
     "DBUserName": "ZTBLAIS_PROD",
     "DBUserPassword": "ZTBLAIS_PROD",
     //"DBDataSource": "10.100.102.130:1521/dimisdb2.l1.local"
-    "DBDataSource": "10.1.100.111:1521/l0devdb1.ztbl.com.pk"
+    "DBDataSource": "10.1.100.111:1521/l0devdb1.ztbl.com.pk",
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=IAS;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "AllowedHosts": "*",
   "SecretKey": "VzZDSrxQ0JfXk1bC/xfptlYg6MWESBuRYc2iNGjaP0o=",


### PR DESCRIPTION
## Summary
- scaffold models `StaffPosition` and `ManpowerDemand`
- update `DBContext` with new DbSets
- wire up `DBContext` in `Startup`
- add placeholder connection string
- add controllers for staff positions and manpower demand
- create basic Razor views for CRUD pages

## Testing
- `dotnet format --verify-no-changes` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c2a64e6bc832eb0e65c5c958bd23a