### PR TITLE
Fix SBPCompliance view paths and configure base URL

### DIFF
--- a/AIS/AIS/Controllers/SBPComplianceController.cs
+++ b/AIS/AIS/Controllers/SBPComplianceController.cs
@@ -32,7 +32,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/Index");
+                return View("~/Views/Complaince/Index.cshtml");
         }
 
         [HttpGet("SBPCompliance/AddObservation")]
@@ -44,7 +44,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/AddObservation");
+                return View("~/Views/Complaince/AddObservation.cshtml");
         }
 
         [HttpGet("SBPCompliance/AssignDivision")]
@@ -56,7 +56,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/AssignDivision");
+                return View("~/Views/Complaince/AssignDivision.cshtml");
         }
 
         [HttpGet("SBPCompliance/AssignDepartment")]
@@ -67,7 +67,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/AssignDepartment");
+                return View("~/Views/Complaince/AssignDepartment.cshtml");
         }
 
         [HttpGet("SBPCompliance/EnterResponse")]
@@ -78,7 +78,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/EnterResponse");
+                return View("~/Views/Complaince/EnterResponse.cshtml");
         }
 
         [HttpGet("SBPCompliance/ReviewResponse")]
@@ -89,7 +89,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/ReviewResponse");
+                return View("~/Views/Complaince/ReviewResponse.cshtml");
         }
 
         [HttpGet("SBPCompliance/ForwardToCompliance")]
@@ -100,7 +100,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/ForwardToCompliance");
+                return View("~/Views/Complaince/ForwardToCompliance.cshtml");
         }
 
         [HttpGet("SBPCompliance/ReviewHistory")]
@@ -111,7 +111,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/ReviewHistory");
+                return View("~/Views/Complaince/ReviewHistory.cshtml");
         }
 
         [HttpGet("SBPCompliance/AuditValidation/{observationId}")]
@@ -122,7 +122,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             else
-                return View("../SBPCompliance/AuditValidation", new AuditValidationModel { ObservationId = observationId });
+                return View("~/Views/Complaince/AuditValidation.cshtml", new AuditValidationModel { ObservationId = observationId });
         }
 
         [HttpPost("SBPCompliance/AuditValidation")]
@@ -144,7 +144,7 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             var history = dBConnection.GetSBPReviewHistory(observationId);
-            return View("../SBPCompliance/ViewHistory", history);
+            return View("~/Views/Complaince/ViewHistory.cshtml", history);
         }
 
         }

--- a/AIS/AIS/Startup.cs
+++ b/AIS/AIS/Startup.cs
@@ -54,7 +54,11 @@ namespace AIS
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
             {
-            app.UsePathBase("/ZTBLAIS/");
+            var baseUrl = Configuration["BaseURL"];
+            if (!string.IsNullOrEmpty(baseUrl))
+            {
+                app.UsePathBase(baseUrl);
+            }
             if (env.IsDevelopment() || env.IsProduction())
                 {
                 app.UseDeveloperExceptionPage();

--- a/AIS/AIS/Views/Shared/_BlankLayout.cshtml
+++ b/AIS/AIS/Views/Shared/_BlankLayout.cshtml
@@ -1,5 +1,6 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
+@inject Microsoft.Extensions.Configuration.IConfiguration Configuration
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,6 +8,7 @@
     <title>@ViewData["Title"] - IAS</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
+    <meta name="base-url" content="@Configuration["BaseURL"]" />
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     
 </head>

--- a/AIS/AIS/Views/Shared/_Layout.cshtml
+++ b/AIS/AIS/Views/Shared/_Layout.cshtml
@@ -1,9 +1,11 @@
 ﻿
 <!DOCTYPE html>
 <html lang="en">
+@inject Microsoft.Extensions.Configuration.IConfiguration Configuration
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="base-url" content="@Configuration["BaseURL"]" />
     <title>@ViewData["Title"] - IAS</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />

--- a/AIS/AIS/wwwroot/js/site.js
+++ b/AIS/AIS/wwwroot/js/site.js
@@ -1,5 +1,6 @@
 ﻿
-var g_asiBaseURL ="/ZTBLAIS";
+var metaBase = document.querySelector('meta[name="base-url"]');
+var g_asiBaseURL = metaBase ? metaBase.getAttribute('content') : "";
 var g_secretKey="";
 var activeRequests = 0;
 


### PR DESCRIPTION
## Summary
- read BaseURL from configuration in Startup
- expose base URL through layouts for client scripts
- read base URL dynamically in site.js
- correct SBPCompliance view paths

## Testing
- `dotnet build AIS/AIS.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc27f27b4832e8d00a1629e6aea09