### PR TITLE
Add export options to FAD tables

### DIFF
--- a/AIS/AIS/Views/FAD/ManpowerDemandIndex.cshtml
+++ b/AIS/AIS/Views/FAD/ManpowerDemandIndex.cshtml
@@ -7,7 +7,7 @@
 <p>
     <a class="btn btn-danger" asp-action="ManpowerDemandCreate">Add New Demand</a>
 </p>
-<table class="table table-bordered table-striped bg-white">
+<table id="manpowerDemandTable" class="table table-bordered table-striped bg-white">
     <thead class="table-success">
         <tr>
             <th>Rank</th>
@@ -33,3 +33,10 @@
     }
     </tbody>
 </table>
+@section Scripts{
+<script>
+    $(document).ready(function(){
+        initializeDataTable('manpowerDemandTable');
+    });
+</script>
+}

--- a/AIS/AIS/Views/FAD/StaffPositionIndex.cshtml
+++ b/AIS/AIS/Views/FAD/StaffPositionIndex.cshtml
@@ -7,7 +7,7 @@
 <p>
     <a class="btn btn-danger" asp-action="StaffPositionCreate">Add New</a>
 </p>
-<table class="table table-bordered table-striped bg-white">
+<table id="staffPositionIndexTable" class="table table-bordered table-striped bg-white">
     <thead class="table-success">
         <tr>
             <th>PPNO</th>
@@ -31,3 +31,10 @@
     }
     </tbody>
 </table>
+@section Scripts{
+<script>
+    $(document).ready(function(){
+        initializeDataTable('staffPositionIndexTable');
+    });
+</script>
+}

--- a/AIS/AIS/Views/FAD/financial_budget.cshtml
+++ b/AIS/AIS/Views/FAD/financial_budget.cshtml
@@ -66,6 +66,7 @@
     function fillSelect(sel,d){var s=$(sel);s.empty();$.each(d,function(i,v){s.append('<option value="'+v.id+'">'+v.description+'</option>');});}
     function loadBudget(){
         $.post(g_asiBaseURL+"/ApiCalls/get_audit_budget",function(data){
+            destroyDatatable('budgetTable');
             var tbody=$("#budgetTable tbody");tbody.empty();var sr=1;
             $.each(data,function(i,v){
                 var row='<tr>'+
@@ -80,6 +81,7 @@
                     '<td><button class="btn btn-sm btn-primary" onclick="editBudget('+v.id+')">Update</button></td>'+
                     '</tr>';tbody.append(row);
             });
+            initializeDataTable('budgetTable');
         });
     }
     function editBudget(id){ $("#budgetId").val(id); $("#budgetModal").modal('show'); }

--- a/AIS/AIS/Views/FAD/manpower_position.cshtml
+++ b/AIS/AIS/Views/FAD/manpower_position.cshtml
@@ -67,6 +67,7 @@
     function fillSelect(sel,d){ var s=$(sel); s.empty(); $.each(d,function(i,v){ s.append('<option value="'+v.id+'">'+v.description+'</option>');}); }
     function loadManpower(){
         $.post(g_asiBaseURL+"/ApiCalls/get_audit_manpower",function(data){
+            destroyDatatable('manpowerTable');
             var tbody=$("#manpowerTable tbody");tbody.empty();var sr=1;
             $.each(data,function(i,v){
                 var row='<tr>'+
@@ -79,6 +80,7 @@
                     '<td><button class="btn btn-sm btn-primary" onclick="editManpower('+v.id+')">Update</button></td>'+
                     '</tr>';tbody.append(row);
             });
+            initializeDataTable('manpowerTable');
         });
     }
     function editManpower(id){ $("#manpowerId").val(id); $("#manpowerModal").modal('show'); }

--- a/AIS/AIS/Views/FAD/observation_review.cshtml
+++ b/AIS/AIS/Views/FAD/observation_review.cshtml
@@ -83,6 +83,7 @@
     }
 
     function getEngagementDetails() {
+        destroyDatatable('engsListPanel');
         $('#engsListPanel tbody').empty();
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/get_engagements_details_for_fad_review",
@@ -104,6 +105,7 @@
 
                     $('#engsListPanel tbody').append('<tr><td class="text-center">' + (i + 1) + '</td><td>' + v.enG_ID + '</td><td>' + v.teaM_NAME + '</td><td>' + v.audiT_START_DATE + '</td><td>' + v.audiT_END_DATE + '</td><td>' + v.oP_START_DATE + '</td><td>' + v.oP_END_DATE + '</td><td>' + v.status + '</td><td class="text-center"><a href="#" class="text-primary" onclick="loadObservationDetails(' + v.enG_ID + ');">View Details</a></td><td class="text-center"><a href="#" class="text-primary" onclick="viewReport(' + v.rpT_ID + ',' + v.enG_ID + ');">View Report</a></td></tr>');
                 });
+                initializeDataTable('engsListPanel');
             },
             dataType: "json",
         });
@@ -112,6 +114,7 @@
 
     function loadObservationDetails(engId) {
         g_engId = parseInt(engId);
+        destroyDatatable('obsListPanel');
         $('#obsListPanel tbody').empty();
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/get_observation_details_for_report",
@@ -135,6 +138,7 @@
                         '<td class="text-center"><a href="#" class="text-primary" onclick="viewPara(' + v.id + ');">View Para</a></td>' +
                         '</tr>');
                  });
+                initializeDataTable('obsListPanel');
             },
             dataType: "json",
         });
@@ -206,6 +210,7 @@
 
     function viewPara(id) {
          g_obsId = parseInt(id);
+        destroyDatatable('paraViewTable');
         $('#paraViewTable tbody').empty();
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/get_observation_details_for_fad",
@@ -236,6 +241,7 @@
                     rows += '<tr><th>Action Required</th><td>' + v.rooT_CAUSE + '</td></tr>';
                     $('#paraViewTable tbody').append(rows);
                 });
+                initializeDataTable('paraViewTable');
                 $('#paraViewModal').modal('show');
             },
             dataType: "json",

--- a/AIS/AIS/Views/FAD/review_gist_recommendation.cshtml
+++ b/AIS/AIS/Views/FAD/review_gist_recommendation.cshtml
@@ -10,6 +10,7 @@
 
     function getEntityObservations() {
         if($('#entitySelectField').val()==0){
+             destroyDatatable('checklistDetailsPanel');
              $('#checklistDetailsPanel tbody').empty();
              return;
         }
@@ -22,6 +23,7 @@
             cache: false,
             success: function (data) {
                 console.log('subhcekclist', data);
+                destroyDatatable('checklistDetailsPanel');
                 $('#checklistDetailsPanel tbody').empty();
                 var sr = 1;
                 $.each(data, function (i, v) {
@@ -39,6 +41,7 @@
                         $('html').scrollTop(rowpos.top);
                     }
                 }, 200)
+                initializeDataTable('checklistDetailsPanel');
 
             },
             dataType: "json",
@@ -72,6 +75,7 @@
                 $('#viewMemo_process_ObSent').html(data[0].process);
                 $('#viewMemo_subprocess_ObSent').html(data[0].suB_PROCESS);
                 $('#viewMemo_violation_ObSent').html(data[0].checklist_Details);
+                destroyDatatable('listofRespPersons_ObSent');
                 $('#listofRespPersons_ObSent tbody').empty();
                 if (data[0].responsiblE_PPs.length > 0) {
                     $.each(data[0].responsiblE_PPs, function (j, pp) {
@@ -79,7 +83,8 @@
                         srNo++;
                         $('#listofRespPersons_ObSent tbody').append('<tr id="tr__ObSent_' + pp.pP_NO + '"><td>' + srNo + '</td><td>' + pp.pP_NO + '</td><td>' + pp.emP_NAME + '</td><td>' + pp.loaN_CASE + '</td><td>' + pp.lC_AMOUNT + '</td><td>' + pp.accounT_NUMBER + '</td><td>' + pp.acC_AMOUNT + '</td></tr>');
                     });
-                }               
+                    initializeDataTable('listofRespPersons_ObSent');
+                }
             },
             dataType: "json",
         });

--- a/AIS/AIS/Views/FAD/risk_register.cshtml
+++ b/AIS/AIS/Views/FAD/risk_register.cshtml
@@ -165,7 +165,14 @@
                 paging: false,
                 searching: false,
                 info: false,
-                ordering: false
+                ordering: false,
+                dom: '<"top"lfB>rt<"bottom"ip><"clear">',
+                buttons: [
+                    { extend: 'pdfHtml5', orientation: 'landscape', pageSize: 'A4' },
+                    { extend: 'excelHtml5', text: 'Export to Excel' },
+                    { extend: 'csvHtml5', text: 'Export to CSV' },
+                    { extend: 'copyHtml5', text: 'Copy to Clipboard' }
+                ]
             });
         });
     </script>

--- a/AIS/AIS/Views/FAD/staff_position.cshtml
+++ b/AIS/AIS/Views/FAD/staff_position.cshtml
@@ -71,6 +71,7 @@
     });
     function loadStaff() {
         $.post(g_asiBaseURL + "/ApiCalls/get_audit_emp", function (data) {
+            destroyDatatable('staffTable');
             var tbody = $("#staffTable tbody");
             tbody.empty();
             var sr = 1;
@@ -91,6 +92,7 @@
                     "</tr>";
                 tbody.append(row);
             });
+            initializeDataTable('staffTable');
         });
     }
     function loadDropdowns() {


### PR DESCRIPTION
## Summary
- enable DataTable export buttons across Financial Budget, Manpower Position, Staff Position, and other FAD views
- add export-enabled DataTables for index views
- extend existing risk register table with export buttons

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d08997d58832ea19136179d1ae482