### PR TITLE
Fix DataTables mismatch in risk register table

### DIFF
--- a/AIS/AIS/Views/FAD/risk_register.cshtml
+++ b/AIS/AIS/Views/FAD/risk_register.cshtml
@@ -39,7 +39,7 @@
     </thead>
     <tbody>
         <tr>
-            <td rowspan="6">Portfolio Management (Lending &amp; Credit Administration / Recovery / Collection &amp; Default Management)</td>
+            <td>Portfolio Management (Lending &amp; Credit Administration / Recovery / Collection &amp; Default Management)</td>
             <td>Pre Sanctioning: Already Mortgaged Land, eCIB Missing, Wrong Feeding of MCL in System</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -49,6 +49,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>Portfolio Management (Lending &amp; Credit Administration / Recovery / Collection &amp; Default Management)</td>
             <td>Pre Sanctioning: Incomplete Loan Documentation, NDC Missing, Old Record, Area Under Preemption etc.</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -58,6 +59,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>Portfolio Management (Lending &amp; Credit Administration / Recovery / Collection &amp; Default Management)</td>
             <td>Pre Sanctioning: Passbook not Revalidated, Debt to Equity, Charge not Confirmed</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -67,6 +69,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>Portfolio Management (Lending &amp; Credit Administration / Recovery / Collection &amp; Default Management)</td>
             <td>Post Sanctioning: Collateral/Security Documentation, Tractor Insurance and Repayment Schedule Delivery</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -76,6 +79,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>Portfolio Management (Lending &amp; Credit Administration / Recovery / Collection &amp; Default Management)</td>
             <td>Post Sanctioning: Tractor Registration, Crop Insurance &amp; Record Digitalization</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -85,6 +89,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>Portfolio Management (Lending &amp; Credit Administration / Recovery / Collection &amp; Default Management)</td>
             <td>Post Sanctioning: Dispatch of Sanction Letter to Borrower</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -94,10 +99,17 @@
             <td class="text-center">2</td>
         </tr>
         <tr class="table-secondary">
-            <td colspan="2"></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
-            <td rowspan="4">Collection, Recovery &amp; Default Management</td>
+            <td>Collection, Recovery &amp; Default Management</td>
             <td>Redemption of Land in Alive Loan Case, Defective and Missing Security/Collaterals Documents</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -107,6 +119,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>Collection, Recovery &amp; Default Management</td>
             <td>Time Barred Loan Cases &amp; Loan Disbursed/Processed on Unpossessed Land</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -116,6 +129,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>Collection, Recovery &amp; Default Management</td>
             <td>Zero/Artificial &amp; Stuck up Recovery Cases, Prudent Recovery Practices, Embezzlement/Misuse of Recovery</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -125,6 +139,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>Collection, Recovery &amp; Default Management</td>
             <td>Demand, Legal &amp; eCIB Notices. Normal Issues in NPL/SAM Loans. Legal Case Management. Pending Installments</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -134,10 +149,17 @@
             <td class="text-center">2</td>
         </tr>
         <tr class="table-secondary">
-            <td colspan="2"></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
-            <td rowspan="4">General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Branch &amp; Vault Security and Cash Operations</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -147,6 +169,7 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Security Stationary Management, Record Keeping, Issuance, Balancing etc.</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
@@ -156,55 +179,94 @@
             <td class="text-center">2</td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Cash with Banker Limits, Insurance of Cash in Hand/Teller/MCO, Cash Operations and Documentation Issues</td>
             <td class="text-center">5</td>
             <td class="text-center">4</td>
             <td class="text-center">20</td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Account Opening, Maintenance &amp; Closing</td>
             <td class="text-center"></td>
             <td class="text-center"></td>
             <td class="text-center"></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Unclaimed Accounts, KYC/CDD, PEP, Proscribe/Designated Persons/Entities, Statement of Account Delivery and Dormancy Notices</td>
             <td class="text-center">5</td>
             <td class="text-center">0</td>
             <td class="text-center">160</td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Biometric Verification of Customers, Customer Profile in CDMS, Account Opening/Operations &amp; Dormancy Violations, CDD &amp; EDD Issues</td>
             <td class="text-center">4</td>
             <td class="text-center">40</td>
             <td class="text-center"></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Issues Related to Zakat Exemption, Deduction, Refund etc.</td>
             <td class="text-center">2</td>
             <td class="text-center">0</td>
             <td class="text-center"></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Cheque Book/ATM/Debit Cards</td>
             <td class="text-center"></td>
             <td class="text-center"></td>
             <td class="text-center"></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Request, Delivery, Stop Payment and Shredding of Cheque Book/ATM/Debit Cards</td>
             <td class="text-center">4</td>
             <td class="text-center">0</td>
             <td class="text-center">0</td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
+            <td>General Banking Operations &amp; Management (Security &amp; Cash Operations, Account Opening, Cheque Book/Debit Card Management, Receipt/Payment Operations &amp; General Controls)</td>
             <td>Payment/Receipt Operations</td>
             <td class="text-center"></td>
             <td class="text-center"></td>
             <td class="text-center"></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr class="table-secondary">
-            <td colspan="2"></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
         <tr>
             <td>Fraud &amp; Forgery, Embezzlement, Impersonation, Parallel Banking etc.</td>
@@ -212,6 +274,9 @@
             <td class="text-center">5</td>
             <td class="text-center">0</td>
             <td class="text-center">0</td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- expand the risk register table rows to avoid using rowspan/colspan
- pad separator rows and incomplete rows so every row has 8 `<td>` elements

## Testing
- `dotnet build -clp:Summary` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d301c18c4832eb708eff0e7670bc5