### PR TITLE
Add I&ID Inquiry skeleton

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3086,6 +3086,85 @@ namespace AIS.Controllers
             return dBConnection.GetSBPReviewHistory(observation_id);
             }
 
+        // ----- I&ID Inquiry API endpoints -----
+
+        [HttpPost]
+        public IActionResult SubmitComplaint([FromForm] AIS.Models.IID.ComplaintModel model)
+            {
+            var id = dBConnection.SubmitComplaint(model);
+            return Ok(new { ComplaintId = id });
+            }
+
+        [HttpPost]
+        public IActionResult AddAssessment([FromBody] AIS.Models.IID.AssessmentModel model)
+            {
+            dBConnection.AddAssessment(model);
+            return Ok();
+            }
+
+        [HttpPost]
+        public IActionResult AddHeadReview([FromBody] AIS.Models.IID.HeadReviewModel model)
+            {
+            dBConnection.AddHeadReview(model);
+            return Ok();
+            }
+
+        [HttpPost]
+        public IActionResult AddInvestigationPlan([FromBody] AIS.Models.IID.InvestigationPlanModel model)
+            {
+            dBConnection.AddInvestigationPlan(model);
+            return Ok();
+            }
+
+        [HttpPost]
+        public IActionResult AddPlanApproval([FromBody] AIS.Models.IID.PlanApprovalModel model)
+            {
+            dBConnection.AddPlanApproval(model);
+            return Ok();
+            }
+
+        [HttpPost]
+        public IActionResult AddInquiryReport([FromForm] AIS.Models.IID.InquiryReportModel model)
+            {
+            dBConnection.AddInquiryReport(model);
+            return Ok();
+            }
+
+        [HttpPost]
+        public IActionResult AddAnalysis([FromBody] AIS.Models.IID.AnalysisModel model)
+            {
+            dBConnection.AddAnalysis(model);
+            return Ok();
+            }
+
+        [HttpPost]
+        public IActionResult AddFinalApproval([FromBody] AIS.Models.IID.FinalApprovalModel model)
+            {
+            dBConnection.AddFinalApproval(model);
+            return Ok();
+            }
+
+        [HttpPost]
+        public IActionResult AddCaseStudy([FromBody] AIS.Models.IID.CaseStudyModel model)
+            {
+            dBConnection.AddCaseStudy(model);
+            return Ok();
+            }
+
+        [HttpPost]
+        public IActionResult GetReports([FromBody] AIS.Models.IID.ReportFilterModel filter)
+            {
+            var list = dBConnection.GetReports(filter);
+            return Ok(list);
+            }
+
+        [HttpPost]
+        public IActionResult GetComplaintsByUser(int userId)
+            {
+            var list = dBConnection.GetComplaintsByUser(userId);
+            return Ok(list);
+            }
+
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
             {

--- a/AIS/AIS/Controllers/IIDController.cs
+++ b/AIS/AIS/Controllers/IIDController.cs
@@ -1,0 +1,130 @@
+using AIS.Models.IID;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+
+namespace AIS.Controllers
+{
+    public class IIDController : Controller
+    {
+        private readonly ILogger<IIDController> _logger;
+        private readonly TopMenus tm;
+        private readonly SessionHandler sessionHandler;
+        private readonly DBConnection dBConnection;
+        public IIDController(ILogger<IIDController> logger, SessionHandler _sessionHandler, DBConnection _dbCon, TopMenus _tpMenu)
+        {
+            _logger = logger;
+            sessionHandler = _sessionHandler;
+            dBConnection = _dbCon;
+            tm = _tpMenu;
+        }
+
+        [HttpGet("iid/submit-complaint")]
+        public IActionResult SubmitComplaint()
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            return View("../IID/SubmitComplaint");
+        }
+
+        [HttpGet("iid/assessment/{complaintId}")]
+        public IActionResult Assessment(int complaintId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            ViewData["ComplaintId"] = complaintId;
+            return View("../IID/InitialAssessment");
+        }
+
+        [HttpGet("iid/head-review/{complaintId}")]
+        public IActionResult HeadReview(int complaintId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            ViewData["ComplaintId"] = complaintId;
+            return View("../IID/HeadReview");
+        }
+
+        [HttpGet("iid/inv-plan/{complaintId}")]
+        public IActionResult InvestigationPlan(int complaintId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            ViewData["ComplaintId"] = complaintId;
+            return View("../IID/InvestigationPlan");
+        }
+
+        [HttpGet("iid/plan-approval/{planId}")]
+        public IActionResult PlanApproval(int planId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            ViewData["PlanId"] = planId;
+            return View("../IID/PlanApproval");
+        }
+
+        [HttpGet("iid/inquiry-report/{complaintId}")]
+        public IActionResult InquiryReport(int complaintId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            ViewData["ComplaintId"] = complaintId;
+            return View("../IID/InquiryReport");
+        }
+
+        [HttpGet("iid/analysis/{reportId}")]
+        public IActionResult Analysis(int reportId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            ViewData["ReportId"] = reportId;
+            return View("../IID/Analysis");
+        }
+
+        [HttpGet("iid/final-approval/{reportId}")]
+        public IActionResult FinalApproval(int reportId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            ViewData["ReportId"] = reportId;
+            return View("../IID/FinalApproval");
+        }
+
+        [HttpGet("iid/case-study/{complaintId}")]
+        public IActionResult CaseStudy(int complaintId)
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            ViewData["ComplaintId"] = complaintId;
+            return View("../IID/CaseStudy");
+        }
+
+        [HttpGet("iid/reports")]
+        public IActionResult Reports()
+        {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            return View("../IID/Reports");
+        }
+    }
+}

--- a/AIS/AIS/DBConnection.IID.cs
+++ b/AIS/AIS/DBConnection.IID.cs
@@ -1,0 +1,25 @@
+using AIS.Models.IID;
+using System.Collections.Generic;
+
+namespace AIS
+{
+    public partial class DBConnection
+    {
+        public int SubmitComplaint(ComplaintModel model)
+        {
+            // Placeholder implementation calling PKG_INQ.ADD_COMPLAINT
+            return 0;
+        }
+
+        public void AddAssessment(AssessmentModel model) { }
+        public void AddHeadReview(HeadReviewModel model) { }
+        public void AddInvestigationPlan(InvestigationPlanModel model) { }
+        public void AddPlanApproval(PlanApprovalModel model) { }
+        public void AddInquiryReport(InquiryReportModel model) { }
+        public void AddAnalysis(AnalysisModel model) { }
+        public void AddFinalApproval(FinalApprovalModel model) { }
+        public void AddCaseStudy(CaseStudyModel model) { }
+        public List<object> GetReports(ReportFilterModel filter) => new List<object>();
+        public List<object> GetComplaintsByUser(int userId) => new List<object>();
+    }
+}

--- a/AIS/AIS/Models/IID/AnalysisModel.cs
+++ b/AIS/AIS/Models/IID/AnalysisModel.cs
@@ -1,0 +1,12 @@
+namespace AIS.Models.IID
+{
+    public class AnalysisModel
+    {
+        public int ReportId { get; set; }
+        public string PolicyGaps { get; set; }
+        public string ControlGaps { get; set; }
+        public string ProceduralViolations { get; set; }
+        public string Comments { get; set; }
+        public bool ReferBack { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/AssessmentModel.cs
+++ b/AIS/AIS/Models/IID/AssessmentModel.cs
@@ -1,0 +1,9 @@
+namespace AIS.Models.IID
+{
+    public class AssessmentModel
+    {
+        public int ComplaintId { get; set; }
+        public string Assessment { get; set; }
+        public string Recommendation { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/CaseStudyModel.cs
+++ b/AIS/AIS/Models/IID/CaseStudyModel.cs
@@ -1,0 +1,17 @@
+namespace AIS.Models.IID
+{
+    public class CaseStudyModel
+    {
+        public int ComplaintId { get; set; }
+        public string OriginatingProcessOwner { get; set; }
+        public string Name { get; set; }
+        public string Branch { get; set; }
+        public string Gist { get; set; }
+        public string Outcome { get; set; }
+        public string ModusOperandi { get; set; }
+        public string Gaps { get; set; }
+        public string RootCause { get; set; }
+        public string ActionsRecommended { get; set; }
+        public string Status { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/ComplaintModel.cs
+++ b/AIS/AIS/Models/IID/ComplaintModel.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Http;
+namespace AIS.Models.IID
+{
+    public class ComplaintModel
+    {
+        public string Nature { get; set; }
+        public string Contents { get; set; }
+        public IFormFile ComplaintFile { get; set; }
+        public IFormFile FfrFile { get; set; }
+        public List<IFormFile> OtherEvidence { get; set; }
+        public string ActionRequired { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/FinalApprovalModel.cs
+++ b/AIS/AIS/Models/IID/FinalApprovalModel.cs
@@ -1,0 +1,9 @@
+namespace AIS.Models.IID
+{
+    public class FinalApprovalModel
+    {
+        public int ReportId { get; set; }
+        public string Comments { get; set; }
+        public bool ReferBack { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/HeadReviewModel.cs
+++ b/AIS/AIS/Models/IID/HeadReviewModel.cs
@@ -1,0 +1,11 @@
+namespace AIS.Models.IID
+{
+    public class HeadReviewModel
+    {
+        public int ComplaintId { get; set; }
+        public string Directions { get; set; }
+        public int AssignedUserId { get; set; }
+        public string Comments { get; set; }
+        public bool ReferBack { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/InquiryReportModel.cs
+++ b/AIS/AIS/Models/IID/InquiryReportModel.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+namespace AIS.Models.IID
+{
+    public class InquiryReportModel
+    {
+        public int ComplaintId { get; set; }
+        public string ReportText { get; set; }
+        public IFormFile ReportFile { get; set; }
+        public List<IFormFile> Evidence { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/InvestigationPlanModel.cs
+++ b/AIS/AIS/Models/IID/InvestigationPlanModel.cs
@@ -1,0 +1,8 @@
+namespace AIS.Models.IID
+{
+    public class InvestigationPlanModel
+    {
+        public int ComplaintId { get; set; }
+        public string Plan { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/PlanApprovalModel.cs
+++ b/AIS/AIS/Models/IID/PlanApprovalModel.cs
@@ -1,0 +1,10 @@
+namespace AIS.Models.IID
+{
+    public class PlanApprovalModel
+    {
+        public int PlanId { get; set; }
+        public string Action { get; set; }
+        public string UpdatedPlan { get; set; }
+        public string FurtherAction { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IID/ReportFilterModel.cs
+++ b/AIS/AIS/Models/IID/ReportFilterModel.cs
@@ -1,0 +1,13 @@
+namespace AIS.Models.IID
+{
+    public class ReportFilterModel
+    {
+        public string Nature { get; set; }
+        public string Complaint { get; set; }
+        public string Accused { get; set; }
+        public string Branch { get; set; }
+        public string Region { get; set; }
+        public string Unit { get; set; }
+        public string Status { get; set; }
+    }
+}

--- a/AIS/AIS/Views/IID/Analysis.cshtml
+++ b/AIS/AIS/Views/IID/Analysis.cshtml
@@ -1,0 +1,39 @@
+@{
+    ViewData["Title"] = "Analysis";
+    Layout = "_Layout";
+    var reportId = ViewData["ReportId"];
+}
+<h4>Analysis</h4>
+<form id="analysisForm">
+    <input type="hidden" name="ReportId" value="@reportId" />
+    <div class="mb-2">
+        <label class="form-label">Policy Gaps</label>
+        <textarea class="form-control" name="PolicyGaps"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Control Gaps</label>
+        <textarea class="form-control" name="ControlGaps"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Procedural Violations</label>
+        <textarea class="form-control" name="ProceduralViolations"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Comments / Refer Back</label>
+        <textarea class="form-control" name="Comments"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Forward</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#analysisForm').on('submit', function(e){
+            e.preventDefault();
+            var data = $(this).serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/AddAnalysis', data, function(){
+                alert('Analysis submitted');
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/CaseStudy.cshtml
+++ b/AIS/AIS/Views/IID/CaseStudy.cshtml
@@ -1,0 +1,63 @@
+@{
+    ViewData["Title"] = "Case Study";
+    Layout = "_Layout";
+    var complaintId = ViewData["ComplaintId"];
+}
+<h4>Case Study</h4>
+<form id="caseForm">
+    <input type="hidden" name="ComplaintId" value="@complaintId" />
+    <div class="mb-2">
+        <label class="form-label">Originating Process Owner</label>
+        <input class="form-control" name="OriginatingProcessOwner" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Name</label>
+        <input class="form-control" name="Name" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Branch</label>
+        <input class="form-control" name="Branch" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Gist</label>
+        <textarea class="form-control" name="Gist"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Outcome</label>
+        <textarea class="form-control" name="Outcome"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Modus Operandi</label>
+        <textarea class="form-control" name="ModusOperandi"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Gaps</label>
+        <textarea class="form-control" name="Gaps"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Root Cause</label>
+        <textarea class="form-control" name="RootCause"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Actions Recommended</label>
+        <textarea class="form-control" name="ActionsRecommended"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Status</label>
+        <input class="form-control" name="Status" />
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#caseForm').on('submit', function(e){
+            e.preventDefault();
+            var data = $(this).serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/AddCaseStudy', data, function(){
+                alert('Case study added');
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/FinalApproval.cshtml
+++ b/AIS/AIS/Views/IID/FinalApproval.cshtml
@@ -1,0 +1,34 @@
+@{
+    ViewData["Title"] = "Final Approval";
+    Layout = "_Layout";
+    var reportId = ViewData["ReportId"];
+}
+<h4>Final Approval</h4>
+<form id="approvalForm">
+    <input type="hidden" name="ReportId" value="@reportId" />
+    <div class="mb-2">
+        <label class="form-label">Comments</label>
+        <textarea class="form-control" name="Comments"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Action</label>
+        <select class="form-select" name="ReferBack">
+            <option value="false">Approve</option>
+            <option value="true">Refer Back</option>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#approvalForm').on('submit', function(e){
+            e.preventDefault();
+            var data = $(this).serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/AddFinalApproval', data, function(){
+                alert('Action saved');
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/HeadReview.cshtml
+++ b/AIS/AIS/Views/IID/HeadReview.cshtml
@@ -1,0 +1,35 @@
+@{
+    ViewData["Title"] = "Head Review";
+    Layout = "_Layout";
+    var complaintId = ViewData["ComplaintId"];
+}
+<h4>Head Review</h4>
+<form id="reviewForm">
+    <input type="hidden" name="ComplaintId" value="@complaintId" />
+    <div class="mb-2">
+        <label class="form-label">Directions</label>
+        <textarea class="form-control" name="Directions"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Assign to I&I Unit</label>
+        <input type="number" class="form-control" name="AssignedUserId" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Refer Back Comments</label>
+        <textarea class="form-control" name="Comments"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#reviewForm').on('submit', function(e){
+            e.preventDefault();
+            var data = $(this).serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/AddHeadReview', data, function(){
+                alert('Review submitted');
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/InitialAssessment.cshtml
+++ b/AIS/AIS/Views/IID/InitialAssessment.cshtml
@@ -1,0 +1,34 @@
+@{
+    ViewData["Title"] = "Initial Assessment";
+    Layout = "_Layout";
+    var complaintId = ViewData["ComplaintId"];
+}
+<h4>Initial Assessment</h4>
+<form id="assessmentForm">
+    <input type="hidden" name="ComplaintId" value="@complaintId" />
+    <div class="mb-2">
+        <label class="form-label">Initial Assessment</label>
+        <textarea class="form-control" name="Assessment"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Recommendation</label>
+        <select class="form-select" name="Recommendation">
+            <option>Qualify</option>
+            <option>Not Qualify</option>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Forward</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#assessmentForm').on('submit', function(e){
+            e.preventDefault();
+            var data = $(this).serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/AddAssessment', data, function(){
+                alert('Assessment submitted');
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/InquiryReport.cshtml
+++ b/AIS/AIS/Views/IID/InquiryReport.cshtml
@@ -1,0 +1,42 @@
+@{
+    ViewData["Title"] = "Inquiry Report";
+    Layout = "_Layout";
+    var complaintId = ViewData["ComplaintId"];
+}
+<h4>Inquiry Report</h4>
+<form id="reportForm" enctype="multipart/form-data">
+    <input type="hidden" name="ComplaintId" value="@complaintId" />
+    <div class="mb-2">
+        <label class="form-label">Report Details</label>
+        <textarea class="form-control" name="ReportText"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Upload Inquiry Report</label>
+        <input type="file" class="form-control" name="ReportFile" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Upload Evidence</label>
+        <input type="file" class="form-control" name="Evidence" multiple />
+    </div>
+    <button type="submit" class="btn btn-primary">Submit Report</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#reportForm').on('submit', function(e){
+            e.preventDefault();
+            var fd = new FormData(this);
+            $.ajax({
+                url: g_asiBaseURL + '/ApiCalls/AddInquiryReport',
+                type: 'POST',
+                data: fd,
+                processData:false,
+                contentType:false,
+                success: function(){
+                    alert('Report submitted');
+                }
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/InvestigationPlan.cshtml
+++ b/AIS/AIS/Views/IID/InvestigationPlan.cshtml
@@ -1,0 +1,27 @@
+@{
+    ViewData["Title"] = "Investigation Plan";
+    Layout = "_Layout";
+    var complaintId = ViewData["ComplaintId"];
+}
+<h4>Investigation Plan</h4>
+<form id="planForm">
+    <input type="hidden" name="ComplaintId" value="@complaintId" />
+    <div class="mb-2">
+        <label class="form-label">Investigation Plan</label>
+        <textarea class="form-control" name="Plan"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit Plan</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#planForm').on('submit', function(e){
+            e.preventDefault();
+            var data = $(this).serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/AddInvestigationPlan', data, function(){
+                alert('Plan submitted');
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/PlanApproval.cshtml
+++ b/AIS/AIS/Views/IID/PlanApproval.cshtml
@@ -1,0 +1,38 @@
+@{
+    ViewData["Title"] = "Plan Approval";
+    Layout = "_Layout";
+    var planId = ViewData["PlanId"];
+}
+<h4>Plan Approval</h4>
+<form id="approvalForm">
+    <input type="hidden" name="PlanId" value="@planId" />
+    <div class="mb-2">
+        <label class="form-label">Edit Plan</label>
+        <textarea class="form-control" name="UpdatedPlan"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Further Line of Action</label>
+        <textarea class="form-control" name="FurtherAction"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Action</label>
+        <select class="form-select" name="Action">
+            <option value="Approve">Approve</option>
+            <option value="Reject">Reject</option>
+        </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#approvalForm').on('submit', function(e){
+            e.preventDefault();
+            var data = $(this).serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/AddPlanApproval', data, function(){
+                alert('Action recorded');
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/Reports.cshtml
+++ b/AIS/AIS/Views/IID/Reports.cshtml
@@ -1,0 +1,54 @@
+@{
+    ViewData["Title"] = "Inquiry Reports";
+    Layout = "_Layout";
+}
+<h4>Inquiry Reports</h4>
+<form id="filterForm" class="row g-2">
+    <div class="col">
+        <input class="form-control" placeholder="Nature" name="Nature" />
+    </div>
+    <div class="col">
+        <input class="form-control" placeholder="Complaint" name="Complaint" />
+    </div>
+    <div class="col">
+        <input class="form-control" placeholder="Accused" name="Accused" />
+    </div>
+    <div class="col">
+        <input class="form-control" placeholder="Branch" name="Branch" />
+    </div>
+    <div class="col">
+        <input class="form-control" placeholder="Region" name="Region" />
+    </div>
+    <div class="col">
+        <input class="form-control" placeholder="Unit" name="Unit" />
+    </div>
+    <div class="col">
+        <input class="form-control" placeholder="Status" name="Status" />
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Search</button>
+    </div>
+</form>
+<table class="table table-sm mt-3" id="resultTable">
+    <thead>
+        <tr><th>Complaint</th><th>Complainant</th><th>Branch</th><th>Date</th><th>Status</th></tr>
+    </thead>
+    <tbody></tbody>
+</table>
+@section Scripts{
+<script>
+    $(function(){
+        $('#filterForm').on('submit', function(e){
+            e.preventDefault();
+            var data = $(this).serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/GetReports', data, function(d){
+                var body = $('#resultTable tbody');
+                body.empty();
+                $.each(d, function(i,v){
+                    body.append('<tr><td>'+v.Complaint+'</td><td>'+v.Complainant+'</td><td>'+v.Branch+'</td><td>'+v.Date+'</td><td>'+v.Status+'</td></tr>');
+                });
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/IID/SubmitComplaint.cshtml
+++ b/AIS/AIS/Views/IID/SubmitComplaint.cshtml
@@ -1,0 +1,52 @@
+@{
+    ViewData["Title"] = "Submit Complaint";
+    Layout = "_Layout";
+}
+<h4>Submit Complaint</h4>
+<form id="complaintForm" enctype="multipart/form-data">
+    <div class="mb-2">
+        <label class="form-label">Nature of Complaint</label>
+        <input type="text" class="form-control" name="Nature" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Contents of Complaint</label>
+        <textarea class="form-control" name="Contents"></textarea>
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Upload Complaint (PDF)</label>
+        <input type="file" class="form-control" name="ComplaintFile" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Upload FFR (PDF)</label>
+        <input type="file" class="form-control" name="FfrFile" />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Upload Other Evidence</label>
+        <input type="file" class="form-control" name="OtherEvidence" multiple />
+    </div>
+    <div class="mb-2">
+        <label class="form-label">Action Required from I&ID</label>
+        <textarea class="form-control" name="ActionRequired"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+@section Scripts{
+<script>
+    $(function(){
+        $('#complaintForm').on('submit', function(e){
+            e.preventDefault();
+            var fd = new FormData(this);
+            $.ajax({
+                url: g_asiBaseURL + '/ApiCalls/SubmitComplaint',
+                type: 'POST',
+                data: fd,
+                processData:false,
+                contentType:false,
+                success: function(d){
+                    alert('Complaint submitted');
+                }
+            });
+        });
+    });
+</script>
+}

--- a/AIS/AIS/Views/Shared/_Layout.cshtml
+++ b/AIS/AIS/Views/Shared/_Layout.cshtml
@@ -145,7 +145,13 @@
                         }
                 }
 
-
+                <div class="dropdown ms-3">
+                    <button class="btn btn-link bg-transparent dropdown-toggle fw-bold" type="button" data-bs-toggle="dropdown">I&amp;ID Inquiry</button>
+                    <ul class="dropdown-menu">
+                        <li><a class="dropdown-item" href="~/iid/submit-complaint">Submit Complaint</a></li>
+                        <li><a class="dropdown-item" href="~/iid/reports">Reports</a></li>
+                    </ul>
+                </div>
 
                 <ul class="navbar-nav mt-2 mt-lg-0 ms-auto">
                     <!-- ms-auto aligns items to the right -->


### PR DESCRIPTION
## Summary
- add new IIDController and placeholder DBConnection methods
- expose API endpoints for I&ID Inquiry workflow
- scaffold models and views for complaint submission and related steps
- add static menu entry for I&ID Inquiry

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee49f1ac0832e860ee9676123ec4f