### PR TITLE
Add annexure instruction support to execution views

### DIFF
--- a/AIS/AIS/Views/Execution/Update_Legacy_Paras.cshtml
+++ b/AIS/AIS/Views/Execution/Update_Legacy_Paras.cshtml
@@ -18,7 +18,33 @@
             fileUpload: false,
             videoEmbed: false,
             urls: false
-        });      
+        });
+
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/GetReferenceTypes",
+            type: "GET",
+            cache: false,
+            success: function (data) {
+                if (data && data.length > 0) {
+                    $.each(data, function (i, v) {
+                        $('#referenceTypeSelect').append(
+                            $('<option>', { value: v.id, text: v.name })
+                        );
+                    });
+                }
+            }
+        });
+
+        $('#referenceTypeSelect').on('change', function () {
+            if ($(this).val() !== "0") {
+                $('#instructionFields').show();
+            } else {
+                $('#instructionFields').hide();
+                $('#instructionsTitle').val('');
+                $('#instructionsDate').val('');
+                $('#instructionsDetails').val('');
+            }
+        });
 
     });
 
@@ -230,7 +256,9 @@
                     
                     $('#observation').html(v.gisT_OF_PARAS);
                     $('#auditCriteriaRiskField').val(0);
-                    $('#responseAuditee').val(v.parA_TEXT).trigger('change');                   
+                    $('#responseAuditee').val(v.parA_TEXT).trigger('change');
+                    $('#legacyAmountInv').val(v.amounT_INVOLVED);
+                    $('#legacyNoInstances').val(v.nO_OF_INSTANCES);
                     $.each(v.parA_RESP,function(i,res){
                         AddNewRespRecord(res.pP_NO, res.emP_NAME, res.loaN_CASE, res.lC_AMOUNT, res.accounT_NUMBER, res.acC_AMOUNT,'checked')
                     });
@@ -373,6 +401,92 @@
         getLegacyPara();
     }
 
+    function submitLegacyParaUpdatesWithReference() {
+        var referenceTypeId = $('#referenceTypeSelect').val();
+        if (referenceTypeId === "0") {
+            alert("Select Reference Type (Manual/Policy/Circular)");
+            return;
+        }
+        var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var instructionsTitle = $('#instructionsTitle').val();
+        var instructionsDate = $('#instructionsDate').val();
+        var instructionsDetails = $('#instructionsDetails').val();
+        if (!instructionsTitle) {
+            alert("Enter Instructions Title");
+            return;
+        }
+        if (!instructionsDate) {
+            alert("Select Instructions Date");
+            return;
+        }
+        if (!instructionsDetails) {
+            alert("Enter Instructions Details");
+            return;
+        }
+
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/UpdateAnnexureInstructions",
+            type: "POST",
+            data: {
+                'ReferenceTypeId': referenceTypeId,
+                'ReferenceType': referenceTypeText,
+                'InstructionsTitle': instructionsTitle,
+                'InstructionsDate': instructionsDate,
+                'InstructionsDetails': instructionsDetails,
+                'CHECKLIST_DETAILS_ID': g_procDetailId
+            },
+            success: function () {
+                submitLegacyParaUpdates();
+            },
+            error: function () {
+                alert("Error saving instructions. Please try again.");
+            }
+        });
+    }
+
+    function submitLegacyParaUpdatesWithReferenceNoChanges() {
+        var referenceTypeId = $('#referenceTypeSelect').val();
+        if (referenceTypeId === "0") {
+            alert("Select Reference Type (Manual/Policy/Circular)");
+            return;
+        }
+        var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var instructionsTitle = $('#instructionsTitle').val();
+        var instructionsDate = $('#instructionsDate').val();
+        var instructionsDetails = $('#instructionsDetails').val();
+        if (!instructionsTitle) {
+            alert("Enter Instructions Title");
+            return;
+        }
+        if (!instructionsDate) {
+            alert("Select Instructions Date");
+            return;
+        }
+        if (!instructionsDetails) {
+            alert("Enter Instructions Details");
+            return;
+        }
+
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/UpdateAnnexureInstructions",
+            type: "POST",
+            data: {
+                'ReferenceTypeId': referenceTypeId,
+                'ReferenceType': referenceTypeText,
+                'InstructionsTitle': instructionsTitle,
+                'InstructionsDate': instructionsDate,
+                'InstructionsDetails': instructionsDetails,
+                'CHECKLIST_DETAILS_ID': g_procDetailId
+            },
+            success: function () {
+                submitLegacyParaUpdatesWithNoChanges();
+            },
+            error: function () {
+                alert("Error saving instructions. Please try again.");
+            }
+        });
+    }
+
     function submitLegacyParaUpdates(){
 
         if(g_entType=="B"){
@@ -454,6 +568,8 @@
             'SUB_PROCESS_ID': g_entType == "B" ? $('#updateMemo_subprocess').val() : $('#riskSubGroupSelectBox').val(),
             'CHECKLIST_DETAIL_ID': g_entType == "B" ? $('#updateMemo_violation').val():0,
             'RISK_ID': $('#auditCriteriaRiskField').val(),
+            'AMOUNT_INV': $('#legacyAmountInv').val(),
+            'NO_INSTANCES': $('#legacyNoInstances').val(),
             'REF_P': g_paraRef,
             'RESP_PP': resP
         };
@@ -542,6 +658,8 @@
             'SUB_PROCESS_ID': g_entType == "B" ? $('#updateMemo_subprocess').val() : $('#riskSubGroupSelectBox').val(),
             'CHECKLIST_DETAIL_ID': g_entType == "B" ? $('#updateMemo_violation').val() : 0,
             'RISK_ID': $('#auditCriteriaRiskField').val(),
+            'AMOUNT_INV': $('#legacyAmountInv').val(),
+            'NO_INSTANCES': $('#legacyNoInstances').val(),
             'REF_P': g_paraRef,
             'RESP_PP': resP
         };
@@ -648,7 +766,7 @@
                     <div class="form-group">
 
                         <label class="font-weight-bold">Risk Category </label>
-                        <select id="auditCriteriaRiskField" class="form-select form-control" aria-label="Default select example">
+                        <select id="auditCriteriaRiskField" class="form-select form-control" aria-label="Default select example" disabled>
                             <option value="0" id="0" selected>--Select Risk Category--</option>
                             @{
                                 if (ViewData["RiskList"] != null)
@@ -663,6 +781,39 @@
                             }
                         </select>
                     </div>
+                    <div class="form-group">
+                        <label for="legacyAmountInv">Amount Involved</label>
+                        <input id="legacyAmountInv" type="text" class="form-control" />
+                    </div>
+                    <div class="form-group">
+                        <label for="legacyNoInstances">No. of Instances</label>
+                        <input id="legacyNoInstances" type="number" min="0" class="form-control" />
+                    </div>
+
+                    <!-- Reference Type and Instructions -->
+                    <div class="form-group mt-3">
+                        <label>Reference Type</label>
+                        <select id="referenceTypeSelect" class="form-select form-control">
+                            <option value="0">--Select Reference Type--</option>
+                        </select>
+                    </div>
+                    <div id="instructionFields" class="form-group mt-3" style="display:none;">
+                        <div class="row">
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Title</label>
+                                <input id="instructionsTitle" type="text" class="form-control" />
+                            </div>
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Date</label>
+                                <input id="instructionsDate" type="date" class="form-control" />
+                            </div>
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Details</label>
+                                <textarea id="instructionsDetails" class="form-control"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- /Reference Type and Instructions -->
 
                     <div class="row mt-3 col-md-12">
                         <label class="font-weight-bold">Para Text</label>
@@ -699,8 +850,8 @@
 
             <div class="mt-3 modal-footer">
                 
-                <button onclick="submitLegacyParaUpdates();" id="PublishParaText" type="button" class="btn btn-danger">Save All Changes</button>
-                <button onclick="submitLegacyParaUpdatesWithNoChanges();" id="PublishParaTextWithNoChanges" type="button" class="btn btn-primary d-none">No change in Para Text</button>
+                <button onclick="submitLegacyParaUpdatesWithReference();" id="PublishParaText" type="button" class="btn btn-danger">Save All Changes</button>
+                <button onclick="submitLegacyParaUpdatesWithReferenceNoChanges();" id="PublishParaTextWithNoChanges" type="button" class="btn btn-primary d-none">No change in Para Text</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
                 
             </div>

--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -21,6 +21,32 @@
         $('#updatedAnnexlist').on('change', updateRiskDisplay);
 
         $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/GetReferenceTypes",
+            type: "GET",
+            cache: false,
+            success: function (data) {
+                if (data && data.length > 0) {
+                    $.each(data, function (i, v) {
+                        $('#referenceTypeSelect').append(
+                            $('<option>', { value: v.id, text: v.name })
+                        );
+                    });
+                }
+            }
+        });
+
+        $('#referenceTypeSelect').on('change', function () {
+            if ($(this).val() !== "0") {
+                $('#instructionFields').show();
+            } else {
+                $('#instructionFields').hide();
+                $('#instructionsTitle').val('');
+                $('#instructionsDate').val('');
+                $('#instructionsDetails').val('');
+            }
+        });
+
+        $.ajax({
             url: g_asiBaseURL + "/ApiCalls/checklist_details",
             type: "POST",
             data: {
@@ -181,7 +207,7 @@
             g_memoObj.push(memo);
 
         $('#viewMemoModel').modal('hide');
-         $.ajax({
+        $.ajax({
             url: g_asiBaseURL + "/ApiCalls/save_observations",
             type: "POST",
             data: {
@@ -195,6 +221,50 @@
                 onAlertCallback(reloadLocation);
             },
             dataType: "json",
+        });
+    }
+
+    function saveMemoContentWithReference() {
+        var referenceTypeId = $('#referenceTypeSelect').val();
+        if (referenceTypeId === "0") {
+            alert("Select Reference Type (Manual/Policy/Circular)");
+            return;
+        }
+        var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var instructionsTitle = $('#instructionsTitle').val();
+        var instructionsDate = $('#instructionsDate').val();
+        var instructionsDetails = $('#instructionsDetails').val();
+        if (!instructionsTitle) {
+            alert("Enter Instructions Title");
+            return;
+        }
+        if (!instructionsDate) {
+            alert("Select Instructions Date");
+            return;
+        }
+        if (!instructionsDetails) {
+            alert("Enter Instructions Details");
+            return;
+        }
+
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/UpdateAnnexureInstructions",
+            type: "POST",
+            data: {
+                'ReferenceTypeId': referenceTypeId,
+                'ReferenceType': referenceTypeText,
+                'InstructionsTitle': instructionsTitle,
+                'InstructionsDate': instructionsDate,
+                'InstructionsDetails': instructionsDetails,
+                'AnnexureId': $('#updatedAnnexlist').val(),
+                'CHECKLIST_DETAILS_ID': 0
+            },
+            success: function () {
+                saveMemoContent();
+            },
+            error: function () {
+                alert("Error saving instructions. Please try again.");
+            }
         });
     }
     function viewCreatedMemo(e, id) {
@@ -577,6 +647,31 @@
                         <label for="viewMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
                         <input id="viewMemo_risk_display" class="form-control" readonly />
                     </div>
+
+                    <!-- Reference Type and Instructions -->
+                    <div class="form-group mt-3">
+                        <label>Reference Type</label>
+                        <select id="referenceTypeSelect" class="form-select form-control">
+                            <option value="0">--Select Reference Type--</option>
+                        </select>
+                    </div>
+                    <div id="instructionFields" class="form-group mt-3" style="display:none;">
+                        <div class="row">
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Title</label>
+                                <input id="instructionsTitle" type="text" class="form-control" />
+                            </div>
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Date</label>
+                                <input id="instructionsDate" type="date" class="form-control" />
+                            </div>
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Details</label>
+                                <textarea id="instructionsDetails" class="form-control"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- /Reference Type and Instructions -->
                     <div class="form-group">
                         <label for="viewMemo_memo">Heading/Title of Para</label>
                         <input id="viewMemo_heading" class="form-control" />
@@ -642,7 +737,7 @@
                 </form>
             </div>
             <div class="modal-footer">
-                <button onclick="saveMemoContent();" type="button" class="btn btn-danger">Save Memo</button>
+                <button onclick="saveMemoContentWithReference();" type="button" class="btn btn-danger">Save Memo</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>

--- a/AIS/AIS/Views/Execution/manage_observations.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations.cshtml
@@ -31,6 +31,32 @@
             videoEmbed: false,
             urls: false
         });
+
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/GetReferenceTypes",
+            type: "GET",
+            cache: false,
+            success: function (data) {
+                if (data && data.length > 0) {
+                    $.each(data, function (i, v) {
+                        $('#referenceTypeSelect').append(
+                            $('<option>', { value: v.id, text: v.name })
+                        );
+                    });
+                }
+            }
+        });
+
+        $('#referenceTypeSelect').on('change', function () {
+            if ($(this).val() !== "0") {
+                $('#instructionFields').show();
+            } else {
+                $('#instructionFields').hide();
+                $('#instructionsTitle').val('');
+                $('#instructionsDate').val('');
+                $('#instructionsDetails').val('');
+            }
+        });
     });
     function reloadLocation() {
         getEntityObservation();
@@ -306,6 +332,7 @@
                 $('#updateMemoContent').val(data[0].obS_TEXT).trigger('change');
                 $('#updateMemo_heading').val(data[0].heading);
                 $('#updateMemo_risk').val(data[0].obS_RISK_ID);
+                $('#updateMemo_instances').val(data[0].nO_OF_INSTANCES);
             },
             dataType: "json",
         });
@@ -321,7 +348,8 @@
                 'OBS_ID': g_obsId,
                 'OBS_TITLE': $('#updateMemo_heading').val(),
                 'RISK_ID': $('#updateMemo_risk').val(),
-                'OBS_TEXT': $('.richText-editor').html()              
+                'OBS_TEXT': $('.richText-editor').html(),
+                'NO_INSTANCES': $('#updateMemo_instances').val()
             },
             cache: false,
             success: function (data) {
@@ -331,6 +359,49 @@
             dataType: "json",
         });
 
+    }
+
+    function finalUpdateMemoContentWithReference(obs_id) {
+        var referenceTypeId = $('#referenceTypeSelect').val();
+        if (referenceTypeId === "0") {
+            alert("Select Reference Type (Manual/Policy/Circular)");
+            return;
+        }
+        var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var instructionsTitle = $('#instructionsTitle').val();
+        var instructionsDate = $('#instructionsDate').val();
+        var instructionsDetails = $('#instructionsDetails').val();
+        if (!instructionsTitle) {
+            alert("Enter Instructions Title");
+            return;
+        }
+        if (!instructionsDate) {
+            alert("Select Instructions Date");
+            return;
+        }
+        if (!instructionsDetails) {
+            alert("Enter Instructions Details");
+            return;
+        }
+
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/UpdateAnnexureInstructions",
+            type: "POST",
+            data: {
+                'ReferenceTypeId': referenceTypeId,
+                'ReferenceType': referenceTypeText,
+                'InstructionsTitle': instructionsTitle,
+                'InstructionsDate': instructionsDate,
+                'InstructionsDetails': instructionsDetails,
+                'CHECKLIST_DETAILS_ID': 0
+            },
+            success: function () {
+                finalUpdateMemoContent(obs_id);
+            },
+            error: function () {
+                alert("Error saving instructions. Please try again.");
+            }
+        });
     }
 
 </script>
@@ -501,7 +572,7 @@
                     </div>
                     <div class="form-group">
                         <label for="updateMemo_risk">Risk</label>
-                        <select id="updateMemo_risk" class="form-select form-control" aria-label="Default select example">
+                        <select id="updateMemo_risk" class="form-select form-control" aria-label="Default select example" disabled>
                             <option value="0" id="0" selected>--Select Risk Category--</option>
                             @{
                                 if (ViewData["RiskList"] != null)
@@ -516,13 +587,42 @@
                             }
                         </select>
                     </div>
+                    <div class="form-group">
+                        <label for="updateMemo_instances">No. of Instances</label>
+                        <input id="updateMemo_instances" type="number" min="0" class="form-control" />
+                    </div>
+
+                    <!-- Reference Type and Instructions -->
+                    <div class="form-group mt-3">
+                        <label>Reference Type</label>
+                        <select id="referenceTypeSelect" class="form-select form-control">
+                            <option value="0">--Select Reference Type--</option>
+                        </select>
+                    </div>
+                    <div id="instructionFields" class="form-group mt-3" style="display:none;">
+                        <div class="row">
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Title</label>
+                                <input id="instructionsTitle" type="text" class="form-control" />
+                            </div>
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Date</label>
+                                <input id="instructionsDate" type="date" class="form-control" />
+                            </div>
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Details</label>
+                                <textarea id="instructionsDetails" class="form-control"></textarea>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- /Reference Type and Instructions -->
 
 
                 </form>
             </div>
             <div class="modal-footer">
 
-                <button id="updateMemoContent_submit" onclick="finalUpdateMemoContent(g_obsId);" type="button" data-bs-dismiss="modal" class="btn btn-danger">Update Memo Text</button>
+                <button id="updateMemoContent_submit" onclick="finalUpdateMemoContentWithReference(g_obsId);" type="button" data-bs-dismiss="modal" class="btn btn-danger">Update Memo Text</button>
 
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>

--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -10,14 +10,40 @@
       var g_subProcId=0;
       var g_procDetailId=0;
 
-     $(document).ready(function () {
-         $('#preConcludingActionHandler').addClass("d-none");
-             $('#viewMemo_memo_ObSent').richText({
-              imageUpload: false,
-              fileUpload: false,
-              videoEmbed: false,
-              urls: false
-          });
+    $(document).ready(function () {
+        $('#preConcludingActionHandler').addClass("d-none");
+            $('#viewMemo_memo_ObSent').richText({
+             imageUpload: false,
+             fileUpload: false,
+             videoEmbed: false,
+             urls: false
+         });
+
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/GetReferenceTypes",
+            type: "GET",
+            cache: false,
+            success: function (data) {
+                if (data && data.length > 0) {
+                    $.each(data, function (i, v) {
+                        $('#referenceTypeSelect').append(
+                            $('<option>', { value: v.id, text: v.name })
+                        );
+                    });
+                }
+            }
+        });
+
+        $('#referenceTypeSelect').on('change', function () {
+            if ($(this).val() !== "0") {
+                $('#instructionFields').show();
+            } else {
+                $('#instructionFields').hide();
+                $('#instructionsTitle').val('');
+                $('#instructionsDate').val('');
+                $('#instructionsDetails').val('');
+            }
+        });
 
             document.getElementById('viewMemo_amount_ObSent').addEventListener('input', function (e) {
         this.value = this.value.replace(/\D|^0(?=\d)/g, ''); // Removes decimals and leading zeros
@@ -117,6 +143,7 @@
            $('#viewMemo_annex_ObSent').val(data.annexurE_ID);
            $('#viewMemo_risk_ObSent').val(data.riskmodeL_ID);
            $('#viewMemo_process_ObSent').val(data.procesS_ID);
+           $('#viewMemo_paraNo_ObSent').val(data.finaL_PARA_NO);
            $('#viewMemo_amount_ObSent').val(data.amounT_INVOLVED);
            $('#viewMemo_inst_ObSent').val(data.nO_OF_INSTANCES);
 
@@ -343,6 +370,49 @@
           return;
       }
 
+      function updateObservationDetailsWithReference(obsId){
+          var referenceTypeId = $('#referenceTypeSelect').val();
+          if(referenceTypeId === "0"){
+              alert("Select Reference Type (Manual/Policy/Circular)");
+              return;
+          }
+          var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+          var instructionsTitle = $('#instructionsTitle').val();
+          var instructionsDate = $('#instructionsDate').val();
+          var instructionsDetails = $('#instructionsDetails').val();
+          if(!instructionsTitle){
+              alert("Enter Instructions Title");
+              return;
+          }
+          if(!instructionsDate){
+              alert("Select Instructions Date");
+              return;
+          }
+          if(!instructionsDetails){
+              alert("Enter Instructions Details");
+              return;
+          }
+
+          $.ajax({
+              url: g_asiBaseURL + "/ApiCalls/UpdateAnnexureInstructions",
+              type: "POST",
+              data: {
+                  'ReferenceTypeId': referenceTypeId,
+                  'ReferenceType': referenceTypeText,
+                  'InstructionsTitle': instructionsTitle,
+                  'InstructionsDate': instructionsDate,
+                  'InstructionsDetails': instructionsDetails,
+                  'CHECKLIST_DETAILS_ID': $('#viewMemo_checklist_ObSent').val()
+              },
+              success: function(){
+                  updateObservationDetails(obsId);
+              },
+              error: function(){
+                  alert("Error saving instructions. Please try again.");
+              }
+          });
+      }
+
       function reloadModel(){
           getEntityObservations();
           viewObservationDetails(g_obsId);
@@ -520,7 +590,7 @@
 
                     <div class="form-group">
                         <label for="viewMemo_risk">Risk</label>
-                        <select id="viewMemo_risk_ObSent" class="form-select form-control" aria-label="Default select example">
+                        <select id="viewMemo_risk_ObSent" class="form-select form-control" disabled aria-label="Default select example">
                             <option value="0" id="0" selected>--Select Risk Category--</option>
                             @{
                                 if (ViewData["RiskList"] != null)
@@ -535,6 +605,32 @@
                             }
                         </select>
 
+                    <div class="form-group">
+                        <label for="viewMemo_paraNo_ObSent" class="font-weight-bold">Para No</label>
+                        <input id="viewMemo_paraNo_ObSent" type="text" class="form-control" />
+                    </div>
+                    <div class="form-group mt-3">
+                        <label>Reference Type</label>
+                        <select id="referenceTypeSelect" class="form-select form-control">
+                            <option value="0">--Select Reference Type--</option>
+                        </select>
+                    </div>
+                    <div id="instructionFields" class="form-group mt-3" style="display:none;">
+                        <div class="row">
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Title</label>
+                                <input id="instructionsTitle" type="text" class="form-control" />
+                            </div>
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Date</label>
+                                <input id="instructionsDate" type="date" class="form-control" />
+                            </div>
+                            <div class="col-md-4 mt-2">
+                                <label>Instructions Details</label>
+                                <textarea id="instructionsDetails" class="form-control"></textarea>
+                            </div>
+                        </div>
+                    </div>
 
                     </div>
                     <div class="form-group">
@@ -609,7 +705,7 @@
             </div>
             <div class="modal-footer">
                 <button id="gist_recom_inc_pre_con" onclick="saveObservationGistandRecommendation(g_obsId);" type="button" class="btn btn-primary">Save Title & Recommendation</button>
-                <button id="update_audit_obs_button" onclick="updateObservationDetails(g_obsId);" type="button" class="btn btn-danger">Update Para Details</button>
+                <button id="update_audit_obs_button" onclick="updateObservationDetailsWithReference(g_obsId);" type="button" class="btn btn-danger">Update Para Details</button>
 
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>


### PR DESCRIPTION
## Summary
- extend update legacy paras view to accept amount, instances and disable risk edit
- add instance tracking to manage observations modal and disable risk edit
- integrate reference type fields in pre concluding audit view with validation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0836d914832e863494aad5ba4de7