### PR TITLE
Add division dropdown linked to reference selection

### DIFF
--- a/AIS/AIS/Views/Execution/Update_Legacy_Paras.cshtml
+++ b/AIS/AIS/Views/Execution/Update_Legacy_Paras.cshtml
@@ -38,13 +38,36 @@
         $('#referenceTypeSelect').on('change', function () {
             if ($(this).val() !== "0") {
                 $('#instructionFields').show();
+                $('#divisionSelect').show();
+                loadDivisions();
             } else {
                 $('#instructionFields').hide();
+                $('#divisionSelect').hide();
                 $('#instructionsTitle').val('');
                 $('#instructionsDate').val('');
                 $('#instructionsDetails').val('');
+                $('#divisionSelect').val('0');
             }
         });
+
+        function loadDivisions() {
+            $('#divisionSelect').empty();
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/getparentrel",
+                type: "POST",
+                data: {
+                    'ENTITY_REALTION_ID': 4
+                },
+                cache: false,
+                success: function (data) {
+                    $('#divisionSelect').append('<option value="0">--Select Division--</option>');
+                    $.each(data, function (i, v) {
+                        $('#divisionSelect').append('<option value="' + v.entitY_ID + '">' + v.description + '</option>');
+                    });
+                },
+                dataType: "json",
+            });
+        }
 
     });
 
@@ -408,9 +431,14 @@
             return;
         }
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
+        if (divisionId === "0") {
+            alert("Select Division");
+            return;
+        }
         if (!instructionsTitle) {
             alert("Enter Instructions Title");
             return;
@@ -433,6 +461,7 @@
                 'InstructionsTitle': instructionsTitle,
                 'InstructionsDate': instructionsDate,
                 'InstructionsDetails': instructionsDetails,
+                'ENTITY_ID': divisionId,
                 'CHECKLIST_DETAILS_ID': g_procDetailId
             },
             success: function () {
@@ -451,9 +480,14 @@
             return;
         }
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
+        if (divisionId === "0") {
+            alert("Select Division");
+            return;
+        }
         if (!instructionsTitle) {
             alert("Enter Instructions Title");
             return;
@@ -476,6 +510,7 @@
                 'InstructionsTitle': instructionsTitle,
                 'InstructionsDate': instructionsDate,
                 'InstructionsDetails': instructionsDetails,
+                'ENTITY_ID': divisionId,
                 'CHECKLIST_DETAILS_ID': g_procDetailId
             },
             success: function () {
@@ -793,9 +828,18 @@
                     <!-- Reference Type and Instructions -->
                     <div class="form-group mt-3">
                         <label>Reference Type</label>
-                        <select id="referenceTypeSelect" class="form-select form-control">
-                            <option value="0">--Select Reference Type--</option>
-                        </select>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <select id="referenceTypeSelect" class="form-select form-control">
+                                    <option value="0">--Select Reference Type--</option>
+                                </select>
+                            </div>
+                            <div class="col-md-6">
+                                <select id="divisionSelect" class="form-select form-control" style="display:none;">
+                                    <option value="0">--Select Division--</option>
+                                </select>
+                            </div>
+                        </div>
                     </div>
                     <div id="instructionFields" class="form-group mt-3" style="display:none;">
                         <div class="row">

--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -479,13 +479,36 @@
         $('#referenceTypeSelect').on('change', function () {
             if ($(this).val() !== "0") {
                 $('#instructionFields').show();
+                $('#divisionSelect').show();
+                loadDivisions();
             } else {
                 $('#instructionFields').hide();
+                $('#divisionSelect').hide();
                 $('#instructionsTitle').val('');
                 $('#instructionsDate').val('');
                 $('#instructionsDetails').val('');
+                $('#divisionSelect').val('0');
             }
         });
+
+        function loadDivisions() {
+            $('#divisionSelect').empty();
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/getparentrel",
+                type: "POST",
+                data: {
+                    'ENTITY_REALTION_ID': 4
+                },
+                cache: false,
+                success: function (data) {
+                    $('#divisionSelect').append('<option value="0">--Select Division--</option>');
+                    $.each(data, function (i, v) {
+                        $('#divisionSelect').append('<option value="' + v.entitY_ID + '">' + v.description + '</option>');
+                    });
+                },
+                dataType: "json",
+            });
+        }
     });
 
     function saveObservation() {
@@ -495,9 +518,15 @@
     function saveObservationWithReference() {
         var referenceTypeId = $('#referenceTypeSelect').val();
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
+
+        if (divisionId === "0") {
+            alert("Select Division");
+            return;
+        }
 
         if (referenceTypeId === "0") {
             alert("Select Reference Type (Manual/Policy/Circular)");
@@ -525,7 +554,8 @@
                 'InstructionsTitle': instructionsTitle,
                 'InstructionsDate': instructionsDate,
                 'InstructionsDetails': instructionsDetails,
-                'AnnexureId': $('#updatedAnnexlist').val()
+                'AnnexureId': $('#updatedAnnexlist').val(),
+                'ENTITY_ID': divisionId
             },
             success: function () {
                 saveObservation();
@@ -564,9 +594,18 @@
     <!-- Reference Type and Instructions (NEW) -->
     <div class="col-md-12 mt-3">
         <h5>Reference Type</h5>
-        <select id="referenceTypeSelect" class="form-select form-control">
-            <option value="0">--Select Reference Type--</option>
-        </select>
+        <div class="row">
+            <div class="col-md-6">
+                <select id="referenceTypeSelect" class="form-select form-control">
+                    <option value="0">--Select Reference Type--</option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <select id="divisionSelect" class="form-select form-control" style="display:none;">
+                    <option value="0">--Select Division--</option>
+                </select>
+            </div>
+        </div>
     </div>
 
     <div id="instructionFields" class="col-md-12 mt-3" style="display:none;">

--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -38,13 +38,36 @@
         $('#referenceTypeSelect').on('change', function () {
             if ($(this).val() !== "0") {
                 $('#instructionFields').show();
+                $('#divisionSelect').show();
+                loadDivisions();
             } else {
                 $('#instructionFields').hide();
+                $('#divisionSelect').hide();
                 $('#instructionsTitle').val('');
                 $('#instructionsDate').val('');
                 $('#instructionsDetails').val('');
+                $('#divisionSelect').val('0');
             }
         });
+
+        function loadDivisions() {
+            $('#divisionSelect').empty();
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/getparentrel",
+                type: "POST",
+                data: {
+                    'ENTITY_REALTION_ID': 4
+                },
+                cache: false,
+                success: function (data) {
+                    $('#divisionSelect').append('<option value="0">--Select Division--</option>');
+                    $.each(data, function (i, v) {
+                        $('#divisionSelect').append('<option value="' + v.entitY_ID + '">' + v.description + '</option>');
+                    });
+                },
+                dataType: "json",
+            });
+        }
 
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/checklist_details",
@@ -231,9 +254,14 @@
             return;
         }
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
+        if (divisionId === "0") {
+            alert("Select Division");
+            return;
+        }
         if (!instructionsTitle) {
             alert("Enter Instructions Title");
             return;
@@ -257,6 +285,7 @@
                 'InstructionsDate': instructionsDate,
                 'InstructionsDetails': instructionsDetails,
                 'AnnexureId': $('#updatedAnnexlist').val(),
+                'ENTITY_ID': divisionId,
                 'CHECKLIST_DETAILS_ID': 0
             },
             success: function () {
@@ -651,9 +680,18 @@
                     <!-- Reference Type and Instructions -->
                     <div class="form-group mt-3">
                         <label>Reference Type</label>
-                        <select id="referenceTypeSelect" class="form-select form-control">
-                            <option value="0">--Select Reference Type--</option>
-                        </select>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <select id="referenceTypeSelect" class="form-select form-control">
+                                    <option value="0">--Select Reference Type--</option>
+                                </select>
+                            </div>
+                            <div class="col-md-6">
+                                <select id="divisionSelect" class="form-select form-control" style="display:none;">
+                                    <option value="0">--Select Division--</option>
+                                </select>
+                            </div>
+                        </div>
                     </div>
                     <div id="instructionFields" class="form-group mt-3" style="display:none;">
                         <div class="row">

--- a/AIS/AIS/Views/Execution/manage_observations.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations.cshtml
@@ -50,13 +50,36 @@
         $('#referenceTypeSelect').on('change', function () {
             if ($(this).val() !== "0") {
                 $('#instructionFields').show();
+                $('#divisionSelect').show();
+                loadDivisions();
             } else {
                 $('#instructionFields').hide();
+                $('#divisionSelect').hide();
                 $('#instructionsTitle').val('');
                 $('#instructionsDate').val('');
                 $('#instructionsDetails').val('');
+                $('#divisionSelect').val('0');
             }
         });
+
+        function loadDivisions() {
+            $('#divisionSelect').empty();
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/getparentrel",
+                type: "POST",
+                data: {
+                    'ENTITY_REALTION_ID': 4
+                },
+                cache: false,
+                success: function (data) {
+                    $('#divisionSelect').append('<option value="0">--Select Division--</option>');
+                    $.each(data, function (i, v) {
+                        $('#divisionSelect').append('<option value="' + v.entitY_ID + '">' + v.description + '</option>');
+                    });
+                },
+                dataType: "json",
+            });
+        }
     });
     function reloadLocation() {
         getEntityObservation();
@@ -368,9 +391,14 @@
             return;
         }
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
+        var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
+        if (divisionId === "0") {
+            alert("Select Division");
+            return;
+        }
         if (!instructionsTitle) {
             alert("Enter Instructions Title");
             return;
@@ -393,6 +421,7 @@
                 'InstructionsTitle': instructionsTitle,
                 'InstructionsDate': instructionsDate,
                 'InstructionsDetails': instructionsDetails,
+                'ENTITY_ID': divisionId,
                 'CHECKLIST_DETAILS_ID': 0
             },
             success: function () {
@@ -595,9 +624,18 @@
                     <!-- Reference Type and Instructions -->
                     <div class="form-group mt-3">
                         <label>Reference Type</label>
-                        <select id="referenceTypeSelect" class="form-select form-control">
-                            <option value="0">--Select Reference Type--</option>
-                        </select>
+                        <div class="row">
+                            <div class="col-md-6">
+                                <select id="referenceTypeSelect" class="form-select form-control">
+                                    <option value="0">--Select Reference Type--</option>
+                                </select>
+                            </div>
+                            <div class="col-md-6">
+                                <select id="divisionSelect" class="form-select form-control" style="display:none;">
+                                    <option value="0">--Select Division--</option>
+                                </select>
+                            </div>
+                        </div>
                     </div>
                     <div id="instructionFields" class="form-group mt-3" style="display:none;">
                         <div class="row">


### PR DESCRIPTION
## Summary
- display division list next to reference when a reference is chosen
- fetch divisions from `getparentrel` API
- require division along with other instruction fields before saving
- pass selected division `ENTITY_ID` to `UpdateAnnexureInstructions`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861145bcb64832e88e1b69c94263912