### PR TITLE
Fix para status approve/reject

### DIFF
--- a/AIS/AIS/Views/PostCompliance/change_para_status_authorize.cshtml
+++ b/AIS/AIS/Views/PostCompliance/change_para_status_authorize.cshtml
@@ -25,12 +25,12 @@
                 g_obsList = data;
                 $.each(data, function (index, child) {
                     $('#manageObsPanel tbody').append('<tr>' +
-                        '<td>' + (child.parA_NO || '') + '</td>' +
-                        '<td>' + (child.audiT_PERIOD || '') + '</td>' +
-                        '<td>' + (child.parA_STATUS || '') + '</td>' +
-                        '<td>' + (child.nEW_PARA_STATUS || '') + '</td>' +
-                        '<td class="text-center"><a class="text-primary" style="cursor:pointer" onclick="paraText(' + child.nEW_PARA_ID + ')">Para Text</a></td>' +
-                        '<td class="text-center"><a class="text-success" style="cursor:pointer" onclick="openAction(\'' + child.cOM_ID + '\',' + child.nEW_PARA_ID + ',' + child.oLD_PARA_ID + ',\'' + child.iND + '\',\'A\')">Approve</a> | <a class="text-danger" style="cursor:pointer" onclick="openAction(\'' + child.cOM_ID + '\',' + child.nEW_PARA_ID + ',' + child.oLD_PARA_ID + ',\'' + child.iND + '\',\'R\')">Reject</a></td>' +
+                        '<td>' + (child.PARA_NO || '') + '</td>' +
+                        '<td>' + (child.AUDIT_PERIOD || '') + '</td>' +
+                        '<td>' + (child.PARA_STATUS || '') + '</td>' +
+                        '<td>' + (child.NEW_PARA_STATUS || '') + '</td>' +
+                        '<td class="text-center"><a class="text-primary" style="cursor:pointer" onclick="paraText(' + child.NEW_PARA_ID + ')">Para Text</a></td>' +
+                        '<td class="text-center"><a class="text-success" style="cursor:pointer" onclick="openAction(\'' + child.COM_ID + '\',' + child.NEW_PARA_ID + ',' + child.OLD_PARA_ID + ',\'' + child.IND + '\',\'A\')">Approve</a> | <a class="text-danger" style="cursor:pointer" onclick="openAction(\'' + child.COM_ID + '\',' + child.NEW_PARA_ID + ',' + child.OLD_PARA_ID + ',\'' + child.IND + '\',\'R\')">Reject</a></td>' +
                         '</tr>');
                 });
             },


### PR DESCRIPTION
## Summary
- fix property names in change_para_status_authorize view so approve/reject buttons work

## Testing
- `dotnet build AIS.sln -clp:ErrorsOnly` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864dc752638832ebc5fce02f20a6eb3