### PR TITLE
Add dynamic title entry

### DIFF
--- a/AIS/AIS/Views/Execution/Update_Legacy_Paras.cshtml
+++ b/AIS/AIS/Views/Execution/Update_Legacy_Paras.cshtml
@@ -11,6 +11,7 @@
     var g_entType="";
   
     var g_paraRef="";
+    var g_instructionMap = [];
 
     $(document).ready(function () {
         $('#responseAuditee').richText({
@@ -48,6 +49,7 @@
                 $('#instructionsDetails').val('');
                 $('#divisionSelect').val('0');
             }
+            tryLoadInstructions();
         });
 
         function loadDivisions() {
@@ -64,11 +66,60 @@
                     $.each(data, function (i, v) {
                         $('#divisionSelect').append('<option value="' + v.entitY_ID + '">' + v.description + '</option>');
                     });
+                    $("#divisionSelect").off('change').on('change', tryLoadInstructions);
                 },
                 dataType: "json",
             });
         }
 
+    });
+
+    function tryLoadInstructions() {
+        var divId = $('#divisionSelect').val();
+        var refId = $('#referenceTypeSelect').val();
+        if (divId !== "0" && refId !== "0") {
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/Ge_Merged_Annexure_Instructions",
+                type: "GET",
+                data: { divisionId: divId, referenceTypeId: refId },
+                success: function (data) {
+                    g_instructionMap = data || [];
+                    $('#instructionsTitle').empty();
+                    $('#instructionsTitle').append('<option value="">--Select or Add Instruction Title--</option>');
+                    if (g_instructionMap.length > 0) {
+                        $.each(g_instructionMap, function (i, v) {
+                            var opt = $('<option>', { value: v.instructionsTitle, text: v.instructionsTitle });
+                            $('#instructionsTitle').append(opt);
+                        });
+                        $('#newInstructionsTitle').hide().val('');
+                    } else {
+                        $('#newInstructionsTitle').show();
+                    }
+                    $('#instructionsTitle').append('<option value="add_new">+ Add New Instruction Title</option>');
+                    $('#instructionsTitle').trigger('change');
+                }
+            });
+        }
+    }
+
+    $('#instructionsTitle').on('change', function () {
+        var selected = $(this).val();
+        if (selected === 'add_new') {
+            $('#newInstructionsTitle').show();
+            $('#instructionsDate').val('');
+            $('#instructionsDetails').val('');
+        } else if (selected) {
+            $('#newInstructionsTitle').hide().val('');
+            const match = (g_instructionMap || []).find(x => x.instructionsTitle === selected);
+            if (match) {
+                $('#instructionsDate').val(match.instructionsDate ? match.instructionsDate.split('T')[0] : '');
+                $('#instructionsDetails').val(match.instructionsDetails || '');
+            }
+        } else {
+            $('#newInstructionsTitle').hide().val('');
+            $('#instructionsDate').val('');
+            $('#instructionsDetails').val('');
+        }
     });
 
     function DeleteRecord(e){
@@ -433,6 +484,9 @@
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
         var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
+        if (instructionsTitle === 'add_new') {
+            instructionsTitle = $('#newInstructionsTitle').val();
+        }
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
         if (divisionId === "0") {
@@ -482,6 +536,9 @@
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
         var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
+        if (instructionsTitle === 'add_new') {
+            instructionsTitle = $('#newInstructionsTitle').val();
+        }
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
         if (divisionId === "0") {
@@ -844,8 +901,11 @@
                     <div id="instructionFields" class="form-group mt-3" style="display:none;">
                         <div class="row">
                             <div class="col-md-4 mt-2">
-                                <label>Instructions Title</label>
-                                <input id="instructionsTitle" type="text" class="form-control" />
+                                <label for="instructionsTitle">Instructions Title</label>
+                                <select id="instructionsTitle" class="form-control">
+                                    <option value="">--Select or Add Instruction Title--</option>
+                                </select>
+                                <input type="text" id="newInstructionsTitle" class="form-control mt-2" placeholder="Enter new title" style="display:none;" />
                             </div>
                             <div class="col-md-4 mt-2">
                                 <label>Instructions Date</label>

--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -15,6 +15,7 @@
     var g_respUser=[];
     var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
     var g_selectedRiskId = 0;
+    var g_instructionMap = [];
     $('#document').ready(function () {
         var url_string = window.location;
         var url = new URL(url_string);
@@ -486,24 +487,24 @@
                     type: "GET",
                     data: { divisionId: divId, referenceTypeId: refId },
                     success: function (data) {
+                        g_instructionMap = data || [];
                         $('#instructionsTitle').empty();
-                        $('#instructionsTitle').append('<option value="">--Select--</option>');
-                        if (data && data.length > 0) {
-                            $.each(data, function (i, v) {
+                        $('#instructionsTitle').append('<option value="">--Select or Add Instruction Title--</option>');
+                        if (g_instructionMap.length > 0) {
+                            $.each(g_instructionMap, function (i, v) {
                                 var opt = $('<option>', { value: v.instructionsTitle, text: v.instructionsTitle });
                                 opt.data('date', v.instructionsDate ? v.instructionsDate.split('T')[0] : '');
                                 opt.data('details', v.instructionsDetails);
                                 $('#instructionsTitle').append(opt);
                             });
-                            $('#instructionsTitle').off('change').on('change', function () {
-                                var sel = $(this).find('option:selected');
-                                $('#instructionsDate').val(sel.data('date') || '');
-                                $('#instructionsDetails').val(sel.data('details') || '');
-                            });
+                            $('#newInstructionsTitle').hide().val('');
                         } else {
+                            $('#newInstructionsTitle').show();
                             $('#instructionsDate').val('');
                             $('#instructionsDetails').val('');
                         }
+                        $('#instructionsTitle').append('<option value="add_new">+ Add New Instruction Title</option>');
+                        $('#instructionsTitle').trigger('change');
                     }
                 });
             }
@@ -523,6 +524,26 @@
                 $('#divisionSelect').val('0');
             }
             tryLoadInstructions();
+        });
+
+        $('#instructionsTitle').on('change', function () {
+            var selected = $(this).val();
+            if (selected === 'add_new') {
+                $('#newInstructionsTitle').show();
+                $('#instructionsDate').val('');
+                $('#instructionsDetails').val('');
+            } else if (selected) {
+                $('#newInstructionsTitle').hide().val('');
+                const match = (g_instructionMap || []).find(x => x.instructionsTitle === selected);
+                if (match) {
+                    $('#instructionsDate').val(match.instructionsDate ? match.instructionsDate.split('T')[0] : '');
+                    $('#instructionsDetails').val(match.instructionsDetails || '');
+                }
+            } else {
+                $('#newInstructionsTitle').hide().val('');
+                $('#instructionsDate').val('');
+                $('#instructionsDetails').val('');
+            }
         });
 
         function loadDivisions() {
@@ -555,6 +576,9 @@
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
         var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
+        if (instructionsTitle === 'add_new') {
+            instructionsTitle = $('#newInstructionsTitle').val();
+        }
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
 
@@ -647,8 +671,11 @@
     <div id="instructionFields" class="col-md-12 mt-3" style="display:none;">
         <div class="row">
             <div class="col-md-4 mt-2">
-                <label>Instructions Title</label>
-                <select id="instructionsTitle" class="form-select form-control"></select>
+                <label for="instructionsTitle">Instructions Title</label>
+                <select id="instructionsTitle" class="form-control">
+                    <option value="">--Select or Add Instruction Title--</option>
+                </select>
+                <input type="text" id="newInstructionsTitle" class="form-control mt-2" placeholder="Enter new title" style="display:none;" />
             </div>
             <div class="col-md-4 mt-2">
                 <label>Instructions Date</label>

--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -11,6 +11,7 @@
     var g_respUsersArr = [];
     var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
     var g_selectedRiskId = 0;
+    var g_instructionMap = [];
     $(document).ready(function () {
         var url_string = window.location;
         var url = new URL(url_string);
@@ -44,24 +45,24 @@
                     type: "GET",
                     data: { divisionId: divId, referenceTypeId: refId },
                     success: function (data) {
+                        g_instructionMap = data || [];
                         $('#instructionsTitle').empty();
-                        $('#instructionsTitle').append('<option value="">--Select--</option>');
-                        if (data && data.length > 0) {
-                            $.each(data, function (i, v) {
+                        $('#instructionsTitle').append('<option value="">--Select or Add Instruction Title--</option>');
+                        if (g_instructionMap.length > 0) {
+                            $.each(g_instructionMap, function (i, v) {
                                 var opt = $('<option>', { value: v.instructionsTitle, text: v.instructionsTitle });
                                 opt.data('date', v.instructionsDate ? v.instructionsDate.split('T')[0] : '');
                                 opt.data('details', v.instructionsDetails);
-                        $('#instructionsTitle').append(opt);
-                    });
-                    $('#instructionsTitle').off('change').on('change', function () {
-                        var sel = $(this).find('option:selected');
-                        $('#instructionsDate').val(sel.data('date') || '');
-                        $('#instructionsDetails').val(sel.data('details') || '');
-                    });
+                                $('#instructionsTitle').append(opt);
+                            });
+                            $('#newInstructionsTitle').hide().val('');
                         } else {
+                            $('#newInstructionsTitle').show();
                             $('#instructionsDate').val('');
                             $('#instructionsDetails').val('');
                         }
+                        $('#instructionsTitle').append('<option value="add_new">+ Add New Instruction Title</option>');
+                        $('#instructionsTitle').trigger('change');
                     }
                 });
             }
@@ -81,6 +82,26 @@
                 $('#divisionSelect').val('0');
             }
             tryLoadInstructions();
+        });
+
+        $('#instructionsTitle').on('change', function () {
+            var selected = $(this).val();
+            if (selected === 'add_new') {
+                $('#newInstructionsTitle').show();
+                $('#instructionsDate').val('');
+                $('#instructionsDetails').val('');
+            } else if (selected) {
+                $('#newInstructionsTitle').hide().val('');
+                const match = (g_instructionMap || []).find(x => x.instructionsTitle === selected);
+                if (match) {
+                    $('#instructionsDate').val(match.instructionsDate ? match.instructionsDate.split('T')[0] : '');
+                    $('#instructionsDetails').val(match.instructionsDetails || '');
+                }
+            } else {
+                $('#newInstructionsTitle').hide().val('');
+                $('#instructionsDate').val('');
+                $('#instructionsDetails').val('');
+            }
         });
 
         function loadDivisions() {
@@ -290,6 +311,9 @@
         var referenceTypeText = $('#referenceTypeSelect option:selected').text();
         var divisionId = $('#divisionSelect').val();
         var instructionsTitle = $('#instructionsTitle').val();
+        if (instructionsTitle === 'add_new') {
+            instructionsTitle = $('#newInstructionsTitle').val();
+        }
         var instructionsDate = $('#instructionsDate').val();
         var instructionsDetails = $('#instructionsDetails').val();
         if (divisionId === "0") {
@@ -730,8 +754,11 @@
                     <div id="instructionFields" class="form-group mt-3" style="display:none;">
                         <div class="row">
                             <div class="col-md-4 mt-2">
-                                <label>Instructions Title</label>
-                                <select id="instructionsTitle" class="form-select form-control"></select>
+                                <label for="instructionsTitle">Instructions Title</label>
+                                <select id="instructionsTitle" class="form-control">
+                                    <option value="">--Select or Add Instruction Title--</option>
+                                </select>
+                                <input type="text" id="newInstructionsTitle" class="form-control mt-2" placeholder="Enter new title" style="display:none;" />
                             </div>
                             <div class="col-md-4 mt-2">
                                 <label>Instructions Date</label>


### PR DESCRIPTION
## Summary
- update instructions title fields to support drop-down with manual entry
- add client-side logic for adding new titles across legacy paras, CAU observation and checklist detail views

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686517245d38832eb42aad575e7c79f7