### PR TITLE
Fix division dropdown and indicator on audit paras

### DIFF
--- a/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
@@ -316,6 +316,8 @@ function updateObservationWithReference() {
             g_annexureRefId = 0;
         }
 
+        var indicatorVal = isAddNew ? 'N' : 'Y';
+
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/UpdateAnnexureInstructions",
             type: "POST",
@@ -327,11 +329,12 @@ function updateObservationWithReference() {
                 'InstructionsDetails': instructionsDetails,
                 'AnnexureId': $('#auditPara_Annex').val(),
                 'ENTITY_ID': divisionId,
-                'ind': isAddNew ? 'N' : 'Y'
+                'ind': indicatorVal
             },
             success: function (resp) {
                 var annexId = resp && resp.annexureRefId ? resp.annexureRefId : 0;
                 g_annexureRefId = annexId;
+                g_ind = indicatorVal;
                 updateObservationStatus();
             },
             error: function () {


### PR DESCRIPTION
## Summary
- add indicator handling when saving reference
- set global indicator after saving reference to maintain state

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686779b50f4c832ea84074ba9d7a950c