### PR TITLE
Fix circular modal stacking and focus

### DIFF
--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -516,7 +516,10 @@
 
         $('#referenceTypeSelect').on('change', function () {
             if ($(this).val() === "3") {
-                $('#circularModal').modal('show');
+                $('.modal').not('#circularModal').modal('hide');
+                setTimeout(function () {
+                    $('#circularModal').modal({ backdrop: 'static', keyboard: false });
+                }, 400);
             } else {
                 g_selectedCircular = null;
                 $('#divisionSelect').prop('disabled', false);
@@ -536,6 +539,10 @@
                 $('#divisionSelect').val('0');
             }
             tryLoadInstructions();
+        });
+
+        $('#circularModal').on('shown.bs.modal', function () {
+            $('#circularSearchText').focus();
         });
 
         $('#instructionCount').hide();
@@ -905,45 +912,6 @@
     </div>
 </div>
 
-<!-- Circular Selection Modal -->
-<div class="modal fade" id="circularModal" tabindex="-1" aria-labelledby="circularModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="circularModalLabel">Select Circular</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="mb-3">
-                    <label class="form-label">Please enter any keyword to search the circular</label>
-                    <input type="text" id="circularSearchText" class="form-control" />
-                    <button type="button" id="btnSearchCircular" class="btn btn-primary mt-2">Search</button>
-                </div>
-                <div class="table-responsive">
-                    <table id="circularResultsTable" class="table table-bordered">
-                        <thead>
-                            <tr>
-                                <th>Select</th>
-                                <th>Circular Reference</th>
-                                <th>Date of Issuance</th>
-                                <th>Subject</th>
-                                <th>Division</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" id="btnAddCircular" class="btn btn-success">Add</button>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
-
-
-<div id="ResponsiblePPModel" class="modal" tabindex="-1" role="dialog">
     <div class="modal-dialog modal-lg" style="min-width:95% !important" role="document">
         <div class="modal-content">
             <div class="modal-header bg-success text-white">
@@ -1013,3 +981,40 @@
     </div>
 </div>
 
+
+<!-- Circular Selection Modal -->
+<div class="modal fade" id="circularModal" tabindex="-1" aria-labelledby="circularModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="circularModalLabel">Select Circular</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label class="form-label">Please enter any keyword to search the circular</label>
+                    <input type="text" id="circularSearchText" class="form-control" />
+                    <button type="button" id="btnSearchCircular" class="btn btn-primary mt-2">Search</button>
+                </div>
+                <div class="table-responsive">
+                    <table id="circularResultsTable" class="table table-bordered">
+                        <thead>
+                            <tr>
+                                <th>Select</th>
+                                <th>Circular Reference</th>
+                                <th>Date of Issuance</th>
+                                <th>Subject</th>
+                                <th>Division</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" id="btnAddCircular" class="btn btn-success">Add</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -73,7 +73,10 @@
 
         $('#referenceTypeSelect').on('change', function () {
             if ($(this).val() === "3") {
-                $('#circularModal').modal('show');
+                $('.modal').not('#circularModal').modal('hide');
+                setTimeout(function () {
+                    $('#circularModal').modal({ backdrop: 'static', keyboard: false });
+                }, 400);
             } else {
                 g_selectedCircular = null;
                 $('#divisionSelect').prop('disabled', false);
@@ -93,6 +96,10 @@
                 $('#divisionSelect').val('0');
             }
             tryLoadInstructions();
+        });
+
+        $('#circularModal').on('shown.bs.modal', function () {
+            $('#circularSearchText').focus();
         });
 
         $('#instructionCount').hide();
@@ -715,45 +722,6 @@
 </div>
 
 
-<!-- Circular Selection Modal -->
-<div class="modal fade" id="circularModal" tabindex="-1" aria-labelledby="circularModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="circularModalLabel">Select Circular</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="mb-3">
-                    <label class="form-label">Please enter any keyword to search the circular</label>
-                    <input type="text" id="circularSearchText" class="form-control" />
-                    <button type="button" id="btnSearchCircular" class="btn btn-primary mt-2">Search</button>
-                </div>
-                <div class="table-responsive">
-                    <table id="circularResultsTable" class="table table-bordered">
-                        <thead>
-                            <tr>
-                                <th>Select</th>
-                                <th>Circular Reference</th>
-                                <th>Date of Issuance</th>
-                                <th>Subject</th>
-                                <th>Division</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" id="btnAddCircular" class="btn btn-success">Add</button>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
-
-
-<div id="viewMemoModel" class="modal" tabindex="-1" role="dialog">
     <div class="modal-dialog modal-xl" role="document">
         <div class="modal-content">
             <div class="modal-header bg-danger text-white">
@@ -1052,3 +1020,40 @@
 </div>
 
 
+
+<!-- Circular Selection Modal -->
+<div class="modal fade" id="circularModal" tabindex="-1" aria-labelledby="circularModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="circularModalLabel">Select Circular</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label class="form-label">Please enter any keyword to search the circular</label>
+                    <input type="text" id="circularSearchText" class="form-control" />
+                    <button type="button" id="btnSearchCircular" class="btn btn-primary mt-2">Search</button>
+                </div>
+                <div class="table-responsive">
+                    <table id="circularResultsTable" class="table table-bordered">
+                        <thead>
+                            <tr>
+                                <th>Select</th>
+                                <th>Circular Reference</th>
+                                <th>Date of Issuance</th>
+                                <th>Subject</th>
+                                <th>Division</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" id="btnAddCircular" class="btn btn-success">Add</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
@@ -45,7 +45,10 @@
 
         $('#referenceTypeSelect').on('change', function () {
             if ($(this).val() === "3") {
-                $('#circularModal').modal('show');
+                $('.modal').not('#circularModal').modal('hide');
+                setTimeout(function () {
+                    $('#circularModal').modal({ backdrop: 'static', keyboard: false });
+                }, 400);
             } else {
                 g_selectedCircular = null;
                 $('#divisionSelect').prop('disabled', false);
@@ -65,6 +68,10 @@
                 $('#divisionSelect').val('0');
             }
             tryLoadInstructions();
+        });
+
+        $('#circularModal').on('shown.bs.modal', function () {
+            $('#circularSearchText').focus();
         });
 
         $('#instructionCount').hide();
@@ -703,44 +710,7 @@ function updateObservationWithReference() {
     </div>
 
 </div>
-<!-- Circular Selection Modal -->
-<div class="modal fade" id="circularModal" tabindex="-1" aria-labelledby="circularModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="circularModalLabel">Select Circular</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="mb-3">
-                    <label class="form-label">Please enter any keyword to search the circular</label>
-                    <input type="text" id="circularSearchText" class="form-control" />
-                    <button type="button" id="btnSearchCircular" class="btn btn-primary mt-2">Search</button>
-                </div>
-                <div class="table-responsive">
-                    <table id="circularResultsTable" class="table table-bordered">
-                        <thead>
-                            <tr>
-                                <th>Select</th>
-                                <th>Circular Reference</th>
-                                <th>Date of Issuance</th>
-                                <th>Subject</th>
-                                <th>Division</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" id="btnAddCircular" class="btn btn-success">Add</button>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-            </div>
-        </div>
-    </div>
-</div>
 
-<div id="viewMemoModel" class="modal" tabindex="-1" role="dialog">
     <div class="modal-dialog modal-xl" role="document">
         <div class="modal-content">
             <div class="modal-header bg-danger text-white">
@@ -976,6 +946,43 @@ function updateObservationWithReference() {
             </div>
             <div class="modal-footer">
                 <button id="addResponsibleButton" onclick="ProceedDeleteDuplicatePara();" type="button" class="btn btn-danger">Request Deletion</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Circular Selection Modal -->
+<div class="modal fade" id="circularModal" tabindex="-1" aria-labelledby="circularModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="circularModalLabel">Select Circular</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label class="form-label">Please enter any keyword to search the circular</label>
+                    <input type="text" id="circularSearchText" class="form-control" />
+                    <button type="button" id="btnSearchCircular" class="btn btn-primary mt-2">Search</button>
+                </div>
+                <div class="table-responsive">
+                    <table id="circularResultsTable" class="table table-bordered">
+                        <thead>
+                            <tr>
+                                <th>Select</th>
+                                <th>Circular Reference</th>
+                                <th>Date of Issuance</th>
+                                <th>Subject</th>
+                                <th>Division</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" id="btnAddCircular" class="btn btn-success">Add</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>

--- a/AIS/AIS/wwwroot/css/site.css
+++ b/AIS/AIS/wwwroot/css/site.css
@@ -209,3 +209,7 @@ table.dataTable thead th {
     border-radius: 0.75rem;
 }
 
+
+#circularModal.modal { z-index: 1100 !important; }
+.modal-backdrop.show { z-index: 1050 !important; }
+


### PR DESCRIPTION
## Summary
- ensure only one modal is visible before showing circular modal
- bump circular modal z-index and backdrop stacking
- focus the search box when circular modal opens
- move circular modal markup to end of page

## Testing
- `dotnet build AIS.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c3a0e7d8832e9cfc911237db786b