### PR TITLE
Fix circular search handlers and observation table

### DIFF
--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -589,37 +589,21 @@
         }
     });
 
-    $('#btnSearchCircular').on('click', function () {
+    $(document).on('click', '#btnSearchCircular', function () {
         var text = $('#circularSearchText').val();
-        $.ajax({
-            url: g_asiBaseURL + "/ApiCalls/GetCirculars",
-            type: "POST",
-            data: { text: text },
-            success: function (data) {
-                var tbody = $('#circularResultsTable tbody');
-                tbody.empty();
-                $.each(data, function (i, v) {
-                    var issue = v.issueDate ? v.issueDate.split('T')[0] : '';
-                    var row = $('<tr>');
-                    row.append('<td><input type="radio" name="circularSelect"></td>');
-                    row.append('<td>' + v.referenceNo + '</td>');
-                    row.append('<td>' + issue + '</td>');
-                    row.append('<td>' + v.displayText + '</td>');
-                    row.append('<td>' + v.division + '</td>');
-                    row.find('input').data('circular', v);
-                    tbody.append(row);
-                });
-            }
-        });
+        searchCirculars(text, '#circularResultsTable')
+            .fail(function () {
+                alert('Failed to retrieve circulars');
+            });
     });
 
-    $('#btnAddCircular').on('click', function () {
-        var selected = $('#circularResultsTable input[name=circularSelect]:checked');
-        if (selected.length === 0) {
+    $(document).on('click', '#btnAddCircular', function () {
+        var selected = getSelectedCircular('#circularResultsTable');
+        if (!selected) {
             alert('Please select a circular');
             return;
         }
-        g_selectedCircular = selected.data('circular');
+        g_selectedCircular = selected;
         $('#circularModal').modal('hide');
         $('#divisionSelect').val(g_selectedCircular.entId).prop('disabled', true);
         if ($('#instructionsTitle').is('select')) {

--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -190,37 +190,19 @@
         }
     }
 
-    $('#btnSearchCircular').on('click', function () {
+    $(document).on('click', '#btnSearchCircular', function () {
         var text = $('#circularSearchText').val();
-        $.ajax({
-            url: g_asiBaseURL + "/ApiCalls/GetCirculars",
-            type: "POST",
-            data: { text: text },
-            success: function (data) {
-                var tbody = $('#circularResultsTable tbody');
-                tbody.empty();
-                $.each(data, function (i, v) {
-                    var issue = v.issueDate ? v.issueDate.split('T')[0] : '';
-                    var row = $('<tr>');
-                    row.append('<td><input type="radio" name="circularSelect"></td>');
-                    row.append('<td>' + v.referenceNo + '</td>');
-                    row.append('<td>' + issue + '</td>');
-                    row.append('<td>' + v.displayText + '</td>');
-                    row.append('<td>' + v.division + '</td>');
-                    row.find('input').data('circular', v);
-                    tbody.append(row);
-                });
-            }
-        });
+        searchCirculars(text, '#circularResultsTable')
+            .fail(function () { alert('Failed to retrieve circulars'); });
     });
 
-    $('#btnAddCircular').on('click', function () {
-        var selected = $('#circularResultsTable input[name=circularSelect]:checked');
-        if (selected.length === 0) {
+    $(document).on('click', '#btnAddCircular', function () {
+        var selected = getSelectedCircular('#circularResultsTable');
+        if (!selected) {
             alert('Please select a circular');
             return;
         }
-        g_selectedCircular = selected.data('circular');
+        g_selectedCircular = selected;
         $('#circularModal').modal('hide');
         $('#divisionSelect').val(g_selectedCircular.entId).prop('disabled', true);
         if ($('#instructionsTitle').is('select')) {

--- a/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
@@ -278,37 +278,19 @@
         ObservationResponsibles(g_index);
     }
 
-    $('#btnSearchCircular').on('click', function () {
+    $(document).on('click', '#btnSearchCircular', function () {
         var text = $('#circularSearchText').val();
-        $.ajax({
-            url: g_asiBaseURL + "/ApiCalls/GetCirculars",
-            type: "POST",
-            data: { text: text },
-            success: function (data) {
-                var tbody = $('#circularResultsTable tbody');
-                tbody.empty();
-                $.each(data, function (i, v) {
-                    var issue = v.issueDate ? v.issueDate.split('T')[0] : '';
-                    var row = $('<tr>');
-                    row.append('<td><input type="radio" name="circularSelect"></td>');
-                    row.append('<td>' + v.referenceNo + '</td>');
-                    row.append('<td>' + issue + '</td>');
-                    row.append('<td>' + v.displayText + '</td>');
-                    row.append('<td>' + v.division + '</td>');
-                    row.find('input').data('circular', v);
-                    tbody.append(row);
-                });
-            }
-        });
+        searchCirculars(text, '#circularResultsTable')
+            .fail(function () { alert('Failed to retrieve circulars'); });
     });
 
-    $('#btnAddCircular').on('click', function () {
-        var selected = $('#circularResultsTable input[name=circularSelect]:checked');
-        if (selected.length === 0) {
+    $(document).on('click', '#btnAddCircular', function () {
+        var selected = getSelectedCircular('#circularResultsTable');
+        if (!selected) {
             alert('Please select a circular');
             return;
         }
-        g_selectedCircular = selected.data('circular');
+        g_selectedCircular = selected;
         $('#circularModal').modal('hide');
         $('#divisionSelect').val(g_selectedCircular.entId).prop('disabled', true);
         if ($('#instructionsTitle').is('select')) {

--- a/AIS/AIS/Views/FAD/observation_review.cshtml
+++ b/AIS/AIS/Views/FAD/observation_review.cshtml
@@ -313,7 +313,8 @@
                 <th class="col-md-auto">Operational Start Date</th>
                 <th class="col-md-auto">Operational End Date</th>
                 <th class="col-md-auto">Status</th>
-                <th colspan="3" class="col-md-auto text-center">Action</th>
+                <th class="col-md-auto text-center">View Details</th>
+                <th class="col-md-auto text-center">View Report</th>
             </tr>
         </thead>
         <tbody></tbody>

--- a/AIS/AIS/Views/Shared/_BlankLayout.cshtml
+++ b/AIS/AIS/Views/Shared/_BlankLayout.cshtml
@@ -36,6 +36,7 @@
     <script src="~/lib/draggable/jquery-ui.js"></script>
     <script type="text/javascript">var page_id = 0;</script>
     <script src="~/js/site.js"></script>
+    <script src="~/js/circular.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>   
     
     @RenderSection("Scripts", required: false)

--- a/AIS/AIS/Views/Shared/_Layout.cshtml
+++ b/AIS/AIS/Views/Shared/_Layout.cshtml
@@ -209,6 +209,7 @@
     <script src="~/js/idleSessionHandler.js"></script>
     <script type="text/javascript">var page_id = 0;</script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/js/circular.js" asp-append-version="true"></script>
     <script type="text/javascript" src="~/lib/rich-text-editor/jquery.richtext.js"></script>
     <script type="text/javascript" src="~/lib/word-export/FileSaver.js"></script>
     <script type="text/javascript" src="~/lib/word-export/jquery.wordexport.js"></script>

--- a/AIS/AIS/wwwroot/js/circular.js
+++ b/AIS/AIS/wwwroot/js/circular.js
@@ -1,0 +1,36 @@
+// Helper functions for Circular search modal
+// Provides common AJAX and DOM update logic so views
+// only supply selectors and handle selected circulars.
+
+function searchCirculars(text, tableSelector) {
+    return $.ajax({
+        url: g_asiBaseURL + "/ApiCalls/GetCirculars",
+        type: "POST",
+        data: { text: text },
+        dataType: "json",
+        cache: false
+    }).done(function (data) {
+        populateCircularResults(data, tableSelector);
+    });
+}
+
+function populateCircularResults(data, tableSelector) {
+    var tbody = $(tableSelector + ' tbody');
+    tbody.empty();
+    $.each(data, function (i, v) {
+        var issue = v.issueDate ? v.issueDate.split('T')[0] : '';
+        var row = $('<tr>');
+        row.append('<td><input type="radio" name="circularSelect"></td>');
+        row.append('<td>' + v.referenceNo + '</td>');
+        row.append('<td>' + issue + '</td>');
+        row.append('<td>' + v.displayText + '</td>');
+        row.append('<td>' + v.division + '</td>');
+        row.find('input').data('circular', v);
+        tbody.append(row);
+    });
+}
+
+function getSelectedCircular(tableSelector) {
+    var selected = $(tableSelector + ' input[name=circularSelect]:checked');
+    return selected.length ? selected.data('circular') : null;
+}


### PR DESCRIPTION
## Summary
- include new `circular.js` with reusable search helpers
- hook the script into both layouts
- use the helpers in observation, checklist and audit para views
- align `observation_review` table header with its row structure

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680fecbe3c832eb77d446b09acfcdd