### PR TITLE
Fix reference fields prefill

### DIFF
--- a/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
@@ -95,9 +95,9 @@
             }
         });
 
-        function tryLoadInstructions() {
+        function tryLoadInstructions(selectedTitle, selectedDate, selectedDetails, refIdOverride) {
             var divId = $('#divisionSelect').val();
-            var refId = $('#referenceTypeSelect').val();
+            var refId = refIdOverride || $('#referenceTypeSelect').val();
             if (divId !== "0" && refId !== "0") {
                 $.ajax({
                     url: g_asiBaseURL + "/ApiCalls/Ge_Merged_Annexure_Instructions",
@@ -122,13 +122,18 @@
                         }
                         $('#instructionsTitle').append('<option value="add_new">+ Add New Title/Chapter</option>');
                         $('#instructionsTitle').select2({ dropdownParent: $('#viewMemoModel') });
+                        if (selectedTitle) {
+                            $('#instructionsTitle').val(selectedTitle);
+                        }
                         $('#instructionsTitle').trigger('change');
+                        if (selectedDate) { $('#instructionsDate').val(selectedDate); }
+                        if (selectedDetails) { $('#instructionsDetails').val(selectedDetails); }
                     }
                 });
             }
         }
 
-        function loadDivisions() {
+        function loadDivisions(selectedId, title, date, details, refId) {
             $('#divisionSelect').empty();
             $.ajax({
                 url: g_asiBaseURL + "/ApiCalls/getparentrel",
@@ -142,7 +147,11 @@
                     $.each(data, function (i, v) {
                         $('#divisionSelect').append('<option value="' + v.entitY_ID + '\">' + v.description + '</option>');
                     });
-                    $("#divisionSelect").off("change").on("change", tryLoadInstructions);
+                    $("#divisionSelect").off("change").on("change", function () { tryLoadInstructions(); });
+                    if (selectedId) {
+                        $('#divisionSelect').val(selectedId);
+                    }
+                    tryLoadInstructions(title, date, details, refId);
                 },
                 dataType: "json",
             });
@@ -217,11 +226,13 @@
                     $('#p_auditPara_InstNO').val(v.nO_INSTANCES);
                     $('#p_paraTextViewer').val(v.parA_TEXT).trigger('change');
                     if (v.referenceTypeId) {
-                        $('#referenceTypeSelect').val(v.referenceTypeId).trigger('change');
-                        $('#divisionSelect').val(v.entityId);
-                        $('#instructionsTitle').val(v.instructionsTitle);
-                        $('#instructionsDate').val(v.instructionsDate ? v.instructionsDate.split('T')[0] : '');
-                        $('#instructionsDetails').val(v.instructionsDetails);
+                        $('#referenceTypeSelect').val(v.referenceTypeId);
+                        $('#instructionFields').show();
+                        $('#divisionSelect').show();
+                        loadDivisions(v.entityId, v.instructionsTitle,
+                            v.instructionsDate ? v.instructionsDate.split('T')[0] : '',
+                            v.instructionsDetails,
+                            v.referenceTypeId);
                         g_annexureRefId = v.annexureRefId || 0;
                     }
 


### PR DESCRIPTION
## Summary
- ensure instructions dropdowns populate after async loads
- load divisions and instructions sequentially when opening existing para

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bab590008832ea56b2ff1b9c3b730