### PR TITLE
Fix disabled fields in manage audit paras view

### DIFF
--- a/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
@@ -695,7 +695,7 @@ function updateObservationStatus(type) {
                             </div>
                             <div class="form-group">
                                 <label for="p_auditPara_Annex" class="font-weight-bold">Annexure</label>
-                                 <select id="p_auditPara_Annex" class="form-select form-control" disabled>
+                                 <select id="p_auditPara_Annex" class="form-select form-control">
                                     <option selected="selected" value="" id="">--Select Annexure--</option>
                                     @{
                                         if (ViewData["AnnexList"] != null)
@@ -752,18 +752,18 @@ function updateObservationStatus(type) {
                                 <label>Reference Type</label>
                                 <div class="row">
                                     <div class="col-md-6">
-                                        <select id="referenceTypeSelect" class="form-select form-control" disabled>
+                                        <select id="referenceTypeSelect" class="form-select form-control">
                                             <option value="0">--Select Reference Type--</option>
                                         </select>
                                     </div>
                                     <div class="col-md-6">
-                                        <select id="divisionSelect" class="form-select form-control" style="display:none;" disabled>
+                                        <select id="divisionSelect" class="form-select form-control" style="display:none;">
                                             <option value="0">--Select Division--</option>
                                         </select>
                                     </div>
                                 </div>
                             </div>
-                            <div id="instructionFields" class="form-group mt-3" style="display:none;" disabled>
+                            <div id="instructionFields" class="form-group mt-3" style="display:none;">
                                 <div class="row">
                                     <div class="col-md-4 mt-2">
                                         <label for="instructionsTitle">Title/Chapter</label>
@@ -775,11 +775,11 @@ function updateObservationStatus(type) {
                                     </div>
                                     <div class="col-md-4 mt-2">
                                         <label>Instructions Date</label>
-                                        <input id="instructionsDate" type="date" class="form-control" disabled />
+                                        <input id="instructionsDate" type="date" class="form-control" />
                                     </div>
                                     <div class="col-md-4 mt-2">
                                         <label>Instructions Details</label>
-                                        <textarea id="instructionsDetails" class="form-control" disabled></textarea>
+                                        <textarea id="instructionsDetails" class="form-control"></textarea>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- enable annexure, reference and instruction fields in `manage_audit_paras_authorized` view

## Testing
- `dotnet build -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb11715e4832e8d0f4540e1d2ba23