### PR TITLE
Fix manage audit paras fields

### DIFF
--- a/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
@@ -225,14 +225,14 @@
                     $('#p_auditPara_ParaNO').val(v.parA_NO);
                     $('#p_auditPara_Annex').val(v.anneX_ID || v.annex);
                     $('#p_auditPara_Gist').val(v.obS_GIST);
-                    $('#p_auditPara_Risk').val(v.obS_RISK_ID || v.obS_RISK);
+                    $('#p_auditPara_Risk').val(v.obS_RISK_ID || v.obS_RISK).prop('readonly', true);
                     $('#p_auditPara_AmountInv').val(v.amounT_INV);
                     $('#p_auditPara_InstNO').val(v.nO_INSTANCES);
                     $('#p_paraTextViewer').val(v.parA_TEXT).trigger('change');
-                    $('#p_auditPara_RefTy').val(v.referencE_TYPE);
-                    $('#p_auditPara_Div').val(v.division);
-                                   $('#p_auditPara_Chap').val(v.instructionS_TITLE);
-                                        $('#p_auditPara_InsDate').val(v.instructionS_DATE);
+                    $('#p_auditPara_RefTy').val(v.referencE_TYPE || v.REFERENCE_TYPE).prop('readonly', true);
+                    $('#p_auditPara_Div').val(v.division || v.DIVISION).prop('readonly', true);
+                    $('#p_auditPara_Chap').val(v.instructionS_TITLE || v.INSTRUCTIONS_TITLE).prop('readonly', true);
+                    $('#p_auditPara_InsDate').val(v.instructionS_DATE || v.INSTRUCTIONS_DATE).prop('readonly', true);
 
                 }
             },
@@ -723,7 +723,7 @@ function updateObservationStatus(type) {
 
                             <div class="form-group">
                                 <label for="p_auditPara_Risk" class="font-weight-bold">Risk</label>
-                                <textarea id="p_auditPara_Risk" class="form-control"></textarea>
+                                <textarea id="p_auditPara_Risk" class="form-control" readonly></textarea>
                             </div>
 
                             <div class="form-group">
@@ -746,20 +746,20 @@ function updateObservationStatus(type) {
                             <!-- Reference Type and Instructions -->
                             <div class="form-group">
                                 <label for="p_auditPara_RefTy" class="font-weight-bold">Reference Type </label>
-                                <input id="p_auditPara_RefTy" class="form-control" type="number" />
+                                <input id="p_auditPara_RefTy" class="form-control" type="text" readonly />
                             
                             <div class="form-group">
                                 <label for="p_auditPara_Div" class="font-weight-bold">Division </label>
-                                <input id="p_auditPara_Div" class="form-control" type="number" />
+                                <input id="p_auditPara_Div" class="form-control" type="text" readonly />
                             </div>
                             <div id="instructionFields" class="form-group mt-3" style="display:none;">
                                 <div class="form-group">
                                     <label for="p_auditPara_Chap" class="font-weight-bold">Title/Chapter </label>
-                                    <input id="p_auditPara_Chap" class="form-control" type="number" />
+                                    <input id="p_auditPara_Chap" class="form-control" type="text" readonly />
                                 </div>
                                 <div class="form-group">
                                     <label for="p_auditPara_InsDate" class="font-weight-bold">Instructions Date </label>
-                                    <input id="p_auditPara_InsDate" class="form-control" type="number" />
+                                    <input id="p_auditPara_InsDate" class="form-control" type="date" readonly />
                                 </div>
                                 </div>
                             <!-- /Reference Type and Instructions -->

--- a/AIS/AIS/wwwroot/js/circular.js
+++ b/AIS/AIS/wwwroot/js/circular.js
@@ -24,7 +24,8 @@ function populateCircularResults(data, tableSelector) {
         row.append('<td>' + v.referenceNo + '</td>');
         row.append('<td>' + issue + '</td>');
         row.append('<td>' + v.displayText + '</td>');
-        row.append('<td>' + v.division + '</td>');
+        var division = v.division || v.Division || v.DIVISION || '';
+        row.append('<td>' + division + '</td>');
         row.find('input').data('circular', v);
         tbody.append(row);
     });


### PR DESCRIPTION
## Summary
- make risk and instruction fields readonly in authorized view
- normalize division column handling

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cdda28984832e9c521c54b55d57ed