### PR TITLE
Fix risk ID handling in authorized audit paras view

### DIFF
--- a/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
@@ -106,7 +106,17 @@
                     $('#p_auditPara_Annex').val(v.anneX_ID || v.annex);
                     updateRiskDisplay();
                     $('#p_auditPara_Gist').val(v.obS_GIST);
-                    $('#p_auditPara_Risk').val(v.obS_RISK || v.obS_RISK_ID).prop('readonly', true);
+                    g_selectedRiskId = parseInt(v.obS_RISK_ID || 0);
+                    $('#p_auditPara_Risk').val(v.obS_RISK).prop('readonly', true);
+                    var color = '';
+                    if ((v.obS_RISK || '').toLowerCase() === 'high') {
+                        color = 'red';
+                    } else if ((v.obS_RISK || '').toLowerCase() === 'medium') {
+                        color = 'gold';
+                    } else if ((v.obS_RISK || '').toLowerCase() === 'low') {
+                        color = 'green';
+                    }
+                    $('#p_auditPara_Risk').css('color', color);
                     $('#p_auditPara_AmountInv').val(v.amounT_INV);
                     $('#p_auditPara_InstNO').val(v.nO_INSTANCES);
                     $('#p_paraTextViewer').val(v.parA_TEXT).trigger('change');
@@ -175,7 +185,7 @@ function updateObservationStatus(type) {
                 'INDICATOR': g_ind,
                 'AUDIT_PERIOD': $('#p_auditPara_Period').val(),
                 'OBS_GIST': $('#p_auditPara_Gist').val(),
-                    'OBS_RISK_ID': $('#v.RISK_ID').val(),
+                'OBS_RISK_ID': g_selectedRiskId,
                 'PARA_NO': $('#p_auditPara_ParaNO').val(),
                 'PARA_TEXT': $('#p_paraTextViewer').val(),
                 'ANNEX_ID': $('#p_auditPara_Annex').val(),
@@ -205,7 +215,7 @@ function updateObservationStatus(type) {
                 'INDICATOR': g_ind,
                 'AUDIT_PERIOD': $('#p_auditPara_Period').val(),
                 'OBS_GIST': $('#p_auditPara_Gist').val(),
-                    'OBS_RISK_ID': $('#v.RISK_ID').val(),
+                'OBS_RISK_ID': g_selectedRiskId,
                 'PARA_NO': $('#p_auditPara_ParaNO').val(),
                 'PARA_TEXT': $('#p_paraTextViewer').val(),
                 'ANNEX_ID': $('#p_auditPara_Annex').val(),


### PR DESCRIPTION
## Summary
- store retrieved risk ID in `g_selectedRiskId`
- show risk text only and colorize it
- send `g_selectedRiskId` to API when authorizing or referring back

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e2a92afb4832e808156434340e230