### PR TITLE
Fix base URL for ManagePublicHolidays page

### DIFF
--- a/AIS/AIS/Views/AdministrationPanel/ManagePublicHolidays.cshtml
+++ b/AIS/AIS/Views/AdministrationPanel/ManagePublicHolidays.cshtml
@@ -44,7 +44,7 @@
 <script>
     function loadHolidays() {
         $.ajax({
-            url: '/ApiCalls/get_all_public_holidays',
+            url: g_asiBaseURL + '/ApiCalls/get_all_public_holidays',
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({ year: new Date().getFullYear() }),
@@ -80,7 +80,7 @@
             };
 
             $.ajax({
-                url: '/ApiCalls/add_public_holiday',
+                url: g_asiBaseURL + '/ApiCalls/add_public_holiday',
                 method: 'POST',
                 contentType: 'application/json',
                 data: JSON.stringify(model),


### PR DESCRIPTION
## Summary
- update `ManagePublicHolidays.cshtml` to use the configured base URL for API calls

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4e05a704832eb59fe7eeece7eadf