### PR TITLE
Implement FAD reference update skeleton

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3307,6 +3307,62 @@ namespace AIS.Controllers
             return dBConnection.GetFadDeskOfficerRptByDateRange(sDate, eDate);
             }
 
+        [HttpPost]
+        public List<AuditEmployeeModel> GetAuditEmployees(int entityId)
+            {
+            return dBConnection.GetAuditEmployees(entityId);
+            }
+
+        [HttpPost]
+        public List<IdNameModel> GetRelationTypes()
+            {
+            return dBConnection.GetRelationTypes();
+            }
+
+        [HttpPost]
+        public List<IdNameModel> GetReportingOffices(int relationTypeId)
+            {
+            return dBConnection.GetReportingOffices(relationTypeId);
+            }
+
+        [HttpPost]
+        public List<EntityModel> GetEntitiesForOffice(int reportingOfficeId)
+            {
+            return dBConnection.GetEntitiesForOffice(reportingOfficeId);
+            }
+
+        [HttpPost]
+        public string AllocateEntitiesToAuditor(int azId, int entId, int auditorPPNO)
+            {
+            var user = sessionHandler.GetSessionUser();
+            return dBConnection.AllocateEntityToAuditor(azId, entId, auditorPPNO, user.PPNumber);
+            }
+
+        [HttpPost]
+        public List<ObservationReferenceModel> GetObservationsForReferenceUpdate(int? entId, int? assignedAuditorId, int? referenceId)
+            {
+            return dBConnection.GetObservationsForReferenceUpdate(entId, assignedAuditorId, referenceId);
+            }
+
+        [HttpPost]
+        public string UpdateParaReference(int comId, int newRef)
+            {
+            var user = sessionHandler.GetSessionUser();
+            return dBConnection.UpdateParaReference(comId, newRef, user.PPNumber);
+            }
+
+        [HttpPost]
+        public List<UpdateLogModel> GetUpdateLog(int comId)
+            {
+            return dBConnection.GetUpdateLog(comId);
+            }
+
+        [HttpPost]
+        public List<ReferenceSearchResultModel> SearchReferences(string referenceType, string keyword)
+            {
+            return dBConnection.SearchReferences(referenceType, keyword);
+            }
+
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
             {

--- a/AIS/AIS/Controllers/FADController.cs
+++ b/AIS/AIS/Controllers/FADController.cs
@@ -358,6 +358,66 @@ namespace AIS.Controllers
             return View("~/Views/FAD/ViewHistory.cshtml", history);
             }
 
+        public IActionResult AllocateEntityToAuditor()
+            {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            else
+                {
+                if (!sessionHandler.HasPermissionToViewPage(MethodBase.GetCurrentMethod().Name))
+                    return RedirectToAction("Index", "PageNotFound");
+                else
+                    return View("~/Views/FAD/AllocateEntityToAuditor.cshtml");
+                }
+            }
+
+        public IActionResult ReferenceUpdateList()
+            {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            else
+                {
+                if (!sessionHandler.HasPermissionToViewPage(MethodBase.GetCurrentMethod().Name))
+                    return RedirectToAction("Index", "PageNotFound");
+                else
+                    return View("~/Views/FAD/ReferenceUpdateList.cshtml");
+                }
+            }
+
+        public IActionResult ReferenceUpdateEdit(int comId)
+            {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            else
+                {
+                if (!sessionHandler.HasPermissionToViewPage(MethodBase.GetCurrentMethod().Name))
+                    return RedirectToAction("Index", "PageNotFound");
+                else
+                    return View("~/Views/FAD/ReferenceUpdateEdit.cshtml", comId);
+                }
+            }
+
+        public IActionResult ReferenceUpdateLog(int comId)
+            {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            else
+                {
+                if (!sessionHandler.HasPermissionToViewPage(MethodBase.GetCurrentMethod().Name))
+                    return RedirectToAction("Index", "PageNotFound");
+                else
+                    return View("~/Views/FAD/ReferenceUpdateLog.cshtml", comId);
+                }
+            }
+
         public IActionResult financial_budget()
             {
             ViewData["TopMenu"] = tm.GetTopMenus();

--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -1,0 +1,276 @@
+using AIS.Models;
+using Oracle.ManagedDataAccess.Client;
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace AIS.Controllers
+{
+    public partial class DBConnection
+    {
+        public List<AuditEmployeeModel> GetAuditEmployees(int entityId)
+        {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+
+            var list = new List<AuditEmployeeModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_GetAuditEmployees";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_entity_id", OracleDbType.Int32).Value = entityId;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            var m = new AuditEmployeeModel();
+                            m.PPNO = rdr["PPNO"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["PPNO"]);
+                            m.DEPARTMENTCODE = rdr["DEPARTMENTCODE"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["DEPARTMENTCODE"]);
+                            m.DESIGNATIONCODE = rdr["DESIGNATIONCODE"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["DESIGNATIONCODE"]);
+                            m.RANKCODE = rdr["RANKCODE"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["RANKCODE"]);
+                            m.DEPTARMENT = rdr["DEPTARMENT"].ToString();
+                            m.EMPLOYEEFIRSTNAME = rdr["EMPLOYEEFIRSTNAME"].ToString();
+                            m.EMPLOYEELASTNAME = rdr["EMPLOYEELASTNAME"].ToString();
+                            m.CURRENT_RANK = rdr["CURRENT_RANK"].ToString();
+                            m.FUN_DESIGNATION = rdr["FUN_DESIGNATION"].ToString();
+                            m.TYPE = rdr["TYPE"].ToString();
+                            list.Add(m);
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+
+        public List<IdNameModel> GetRelationTypes()
+        {
+            var list = new List<IdNameModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_GetRelationTypes";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            list.Add(new IdNameModel
+                            {
+                                Id = rdr["ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["ID"]),
+                                Name = rdr["NAME"].ToString()
+                            });
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+
+        public List<IdNameModel> GetReportingOffices(int relationTypeId)
+        {
+            var list = new List<IdNameModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_GetReportingOffices";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_relation_id", OracleDbType.Int32).Value = relationTypeId;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            list.Add(new IdNameModel
+                            {
+                                Id = rdr["ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["ID"]),
+                                Name = rdr["NAME"].ToString()
+                            });
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+
+        public List<EntityModel> GetEntitiesForOffice(int reportingOfficeId)
+        {
+            var list = new List<EntityModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_GetEntitiesForOffice";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_office_id", OracleDbType.Int32).Value = reportingOfficeId;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            list.Add(new EntityModel
+                            {
+                                EntityId = rdr["ENTITY_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["ENTITY_ID"]),
+                                Name = rdr["NAME"].ToString(),
+                                Type = rdr["TYPE"]?.ToString(),
+                                TotalParas = rdr["TOTAL_PARAS"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["TOTAL_PARAS"])
+                            });
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+
+        public string AllocateEntityToAuditor(int azId, int entId, int auditorPPNO, int assignedBy)
+        {
+            string resp = string.Empty;
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_allocate_entity_to_auditor";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_az_id", OracleDbType.Int32).Value = azId;
+                    cmd.Parameters.Add("p_ent_id", OracleDbType.Int32).Value = entId;
+                    cmd.Parameters.Add("p_auditor_ppno", OracleDbType.Int32).Value = auditorPPNO;
+                    cmd.Parameters.Add("p_assigned_by", OracleDbType.Int32).Value = assignedBy;
+                    cmd.Parameters.Add("io_msg", OracleDbType.Varchar2, 200).Direction = ParameterDirection.Output;
+                    cmd.ExecuteNonQuery();
+                    resp = cmd.Parameters["io_msg"].Value?.ToString();
+                }
+            }
+            return resp;
+        }
+
+        public List<ObservationReferenceModel> GetObservationsForReferenceUpdate(int? entId, int? assignedAuditorId, int? referenceId)
+        {
+            var list = new List<ObservationReferenceModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_GetObservationsForReferenceUpdate";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_ent_id", OracleDbType.Int32).Value = entId ?? (object)DBNull.Value;
+                    cmd.Parameters.Add("p_auditor", OracleDbType.Int32).Value = assignedAuditorId ?? (object)DBNull.Value;
+                    cmd.Parameters.Add("p_ref_id", OracleDbType.Int32).Value = referenceId ?? (object)DBNull.Value;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            list.Add(new ObservationReferenceModel
+                            {
+                                ComId = rdr["COM_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["COM_ID"]),
+                                EntId = rdr["ENT_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["ENT_ID"]),
+                                ParaTitle = rdr["PARA_TITLE"].ToString(),
+                                ReferenceId = rdr["REFERENCE_ID"] == DBNull.Value ? null : (int?)Convert.ToInt32(rdr["REFERENCE_ID"]),
+                                ReferenceType = rdr["REFERENCE_TYPE"].ToString(),
+                                AssignedAuditorId = rdr["ASSIGNED_AUDITOR"] == DBNull.Value ? null : (int?)Convert.ToInt32(rdr["ASSIGNED_AUDITOR"]),
+                                Status = rdr["STATUS"].ToString()
+                            });
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+
+        public string UpdateParaReference(int comId, int newRef, int updatedBy)
+        {
+            string resp = string.Empty;
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_update_para_reference";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("p_new_ref", OracleDbType.Int32).Value = newRef;
+                    cmd.Parameters.Add("p_updated_by", OracleDbType.Int32).Value = updatedBy;
+                    cmd.Parameters.Add("io_msg", OracleDbType.Varchar2, 200).Direction = ParameterDirection.Output;
+                    cmd.ExecuteNonQuery();
+                    resp = cmd.Parameters["io_msg"].Value?.ToString();
+                }
+            }
+            return resp;
+        }
+
+        public List<UpdateLogModel> GetUpdateLog(int comId)
+        {
+            var list = new List<UpdateLogModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_get_update_log";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            list.Add(new UpdateLogModel
+                            {
+                                Date = rdr["ACTION_DATE"] == DBNull.Value ? DateTime.MinValue : Convert.ToDateTime(rdr["ACTION_DATE"]),
+                                User = rdr["ACTION_USER"].ToString(),
+                                Field = rdr["ACTION_FIELD"].ToString(),
+                                OldValue = rdr["OLD_VALUE"].ToString(),
+                                NewValue = rdr["NEW_VALUE"].ToString(),
+                                ActionType = rdr["ACTION_TYPE"].ToString()
+                            });
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+
+        public List<ReferenceSearchResultModel> SearchReferences(string referenceType, string keyword)
+        {
+            var list = new List<ReferenceSearchResultModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "P_SearchReferences";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_ref_type", OracleDbType.Varchar2).Value = referenceType;
+                    cmd.Parameters.Add("p_keyword", OracleDbType.Varchar2).Value = keyword;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            list.Add(new ReferenceSearchResultModel
+                            {
+                                ReferenceId = rdr["REFERENCE_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["REFERENCE_ID"]),
+                                Title = rdr["TITLE"].ToString(),
+                                ReferenceType = rdr["REFERENCE_TYPE"].ToString()
+                            });
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+    }
+}

--- a/AIS/AIS/Models/EntityModel.cs
+++ b/AIS/AIS/Models/EntityModel.cs
@@ -1,0 +1,10 @@
+namespace AIS.Models
+{
+    public class EntityModel
+    {
+        public int EntityId { get; set; }
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public int TotalParas { get; set; }
+    }
+}

--- a/AIS/AIS/Models/IdNameModel.cs
+++ b/AIS/AIS/Models/IdNameModel.cs
@@ -1,0 +1,8 @@
+namespace AIS.Models
+{
+    public class IdNameModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/AIS/AIS/Models/ObservationReferenceModel.cs
+++ b/AIS/AIS/Models/ObservationReferenceModel.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace AIS.Models
+{
+    public class ObservationReferenceModel
+    {
+        public int ComId { get; set; }
+        public int EntId { get; set; }
+        public string ParaTitle { get; set; }
+        public int? ReferenceId { get; set; }
+        public string ReferenceType { get; set; }
+        public int? AssignedAuditorId { get; set; }
+        public string Status { get; set; }
+    }
+}

--- a/AIS/AIS/Models/ReferenceSearchResultModel.cs
+++ b/AIS/AIS/Models/ReferenceSearchResultModel.cs
@@ -1,0 +1,9 @@
+namespace AIS.Models
+{
+    public class ReferenceSearchResultModel
+    {
+        public int ReferenceId { get; set; }
+        public string Title { get; set; }
+        public string ReferenceType { get; set; }
+    }
+}

--- a/AIS/AIS/Models/UpdateLogModel.cs
+++ b/AIS/AIS/Models/UpdateLogModel.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace AIS.Models
+{
+    public class UpdateLogModel
+    {
+        public DateTime Date { get; set; }
+        public string User { get; set; }
+        public string Field { get; set; }
+        public string OldValue { get; set; }
+        public string NewValue { get; set; }
+        public string ActionType { get; set; }
+    }
+}

--- a/AIS/AIS/Views/FAD/AllocateEntityToAuditor.cshtml
+++ b/AIS/AIS/Views/FAD/AllocateEntityToAuditor.cshtml
@@ -1,0 +1,69 @@
+@{
+    ViewData["Title"] = "Allocate Entity To Auditor";
+    Layout = "_Layout";
+}
+<h4>Allocate Entity To Auditor</h4>
+<button id="openAllocateModal" class="btn btn-primary mb-3">Assign Entity</button>
+<div class="modal fade" id="allocateModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Allocate Entity</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <select id="relationType" class="form-select mb-2"></select>
+                <select id="reportingOffice" class="form-select mb-2"></select>
+                <table class="table" id="entitiesTable">
+                    <thead><tr><th></th><th>Entity</th></tr></thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+            <div class="modal-footer">
+                <button id="allocateBtn" class="btn btn-primary" disabled>Allocate</button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(function(){
+    $('#openAllocateModal').click(function(){
+        $('#allocateModal').modal('show');
+        $.post(g_asiBaseURL+'/ApiCalls/GetRelationTypes',function(d){
+            var sel=$('#relationType'); sel.empty().append('<option value="">Relation Type</option>');
+            $.each(d,function(i,it){ sel.append('<option value="'+it.id+'">'+it.name+'</option>');});
+        });
+    });
+    $('#relationType').change(function(){
+        var id=$(this).val();
+        $('#reportingOffice').empty().append('<option value="">Reporting Office</option>');
+        if(id){
+            $.post(g_asiBaseURL+'/ApiCalls/GetReportingOffices',{relationTypeId:id},function(d){
+                $.each(d,function(i,it){$('#reportingOffice').append('<option value="'+it.id+'">'+it.name+'</option>');});
+            });
+        }
+    });
+    $('#reportingOffice').change(function(){
+        var id=$(this).val();
+        $('#entitiesTable tbody').empty();
+        if(id){
+            $.post(g_asiBaseURL+'/ApiCalls/GetEntitiesForOffice',{reportingOfficeId:id},function(d){
+                $.each(d,function(i,it){
+                    $('#entitiesTable tbody').append('<tr><td><input type="checkbox" class="entChk" value="'+it.entityId+'"/></td><td>'+it.name+'</td></tr>');
+                });
+            });
+        }
+    });
+    $(document).on('change','.entChk',function(){
+        $('#allocateBtn').prop('disabled',$('.entChk:checked').length==0);
+    });
+    $('#allocateBtn').click(function(){
+        var ent=$('.entChk:checked').first().val();
+        if(!ent) return;
+        var auditorPPNO=@(Context.Session.GetInt32("PPNumber") ?? 0);
+        $.post(g_asiBaseURL+'/ApiCalls/AllocateEntitiesToAuditor',{azId:0,entId:ent,auditorPPNO:auditorPPNO},function(){
+            $('#allocateModal').modal('hide');
+        });
+    });
+});
+</script>

--- a/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
@@ -1,0 +1,39 @@
+@model int
+@{
+    ViewData["Title"] = "Update Reference";
+    Layout = "_Layout";
+}
+<h4>Update Reference</h4>
+<div id="refInfo"></div>
+<div id="searchSection">
+    <select id="refType" class="form-select mb-2">
+        <option value="Manual">Manual</option>
+        <option value="Policy">Policy</option>
+        <option value="Circular">Circular</option>
+    </select>
+    <input id="keyword" class="form-control mb-2" placeholder="keyword" />
+    <button class="btn btn-primary" id="searchBtn">Search</button>
+</div>
+<table class="table" id="resultTbl">
+    <thead><tr><th>Title</th><th>Action</th></tr></thead>
+    <tbody></tbody>
+</table>
+<script>
+$(function(){
+    var comId=@Model;
+    $('#searchBtn').click(function(){
+        $.post(g_asiBaseURL+'/ApiCalls/SearchReferences',{referenceType:$('#refType').val(),keyword:$('#keyword').val()},function(d){
+            var body=$('#resultTbl tbody');body.empty();
+            $.each(d,function(i,it){
+                body.append('<tr><td>'+it.title+'</td><td><button class="attach btn btn-sm btn-primary" data-id="'+it.referenceId+'">Attach</button></td></tr>');
+            });
+        });
+    });
+    $(document).on('click','.attach',function(){
+        var ref=$(this).data('id');
+        $.post(g_asiBaseURL+'/ApiCalls/UpdateParaReference',{comId:comId,newRef:ref},function(){
+            window.location.href=g_asiBaseURL+'/FAD/ReferenceUpdateList';
+        });
+    });
+});
+</script>

--- a/AIS/AIS/Views/FAD/ReferenceUpdateList.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateList.cshtml
@@ -1,0 +1,19 @@
+@{
+    ViewData["Title"] = "Reference Update";
+    Layout = "_Layout";
+}
+<h4>Observations Assigned</h4>
+<table class="table" id="obsTable">
+    <thead><tr><th>Entity</th><th>Para</th><th>Action</th></tr></thead>
+    <tbody></tbody>
+</table>
+<script>
+$(function(){
+    $.post(g_asiBaseURL+'/ApiCalls/GetObservationsForReferenceUpdate',{},function(d){
+        var body=$('#obsTable tbody');
+        $.each(d,function(i,it){
+            body.append('<tr><td>'+it.entId+'</td><td>'+it.paraTitle+'</td><td><a href="'+g_asiBaseURL+'/FAD/ReferenceUpdateEdit?comId='+it.comId+'">Assign Reference</a></td></tr>');
+        });
+    });
+});
+</script>

--- a/AIS/AIS/Views/FAD/ReferenceUpdateLog.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateLog.cshtml
@@ -1,0 +1,20 @@
+@model int
+@{
+    ViewData["Title"] = "Update Log";
+    Layout = "_Layout";
+}
+<h4>Update Log</h4>
+<table class="table" id="logTable">
+    <thead><tr><th>Date</th><th>User</th><th>Field</th><th>Old</th><th>New</th><th>Action</th></tr></thead>
+    <tbody></tbody>
+</table>
+<script>
+$(function(){
+    $.post(g_asiBaseURL+'/ApiCalls/GetUpdateLog',{comId:@Model},function(d){
+        var body=$('#logTable tbody');
+        $.each(d,function(i,it){
+            body.append('<tr><td>'+it.date+'</td><td>'+it.user+'</td><td>'+it.field+'</td><td>'+it.oldValue+'</td><td>'+it.newValue+'</td><td>'+it.actionType+'</td></tr>');
+        });
+    });
+});
+</script>

--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ The Commercial Audit (CA) menu provides a basic ARPSE PARA workflow.  Screens ex
 `ApiCallsController` now contains stubbed endpoints such as `ca_submit_to_headfad`, `ca_assign_division`, `ca_department_response` and others.  These call corresponding placeholder methods in `DBConnection` which will later persist Commercial Audit data.
 
 The `LegacyEntry` page allows authorized users to capture historical observations with fields for year, text, division, department, status and supporting documents.  Submitted data is posted to the `ca_enter_legacy_observation` endpoint.
+
+## FAD Reference Update & Allocation
+
+New views under `Views/FAD` allow FAD incharges to allocate entities to auditors and manage reference updates on observations.  The API endpoints exposed through `ApiCallsController` use new `DBConnection` methods to fetch employees, reporting offices, search references and maintain an update log.


### PR DESCRIPTION
## Summary
- add stub DBConnection methods for FAD reference allocation
- expose new allocation and reference API endpoints
- add controller actions for allocating entities and updating references
- create basic Razor pages for new FAD workflows
- document the new feature in the README

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687270aedaec832e9d46bb1ef8bfa6cf