### PR TITLE
Add session setup to DBConnection methods

### DIFF
--- a/AIS/AIS/DBConnection.CA.cs
+++ b/AIS/AIS/DBConnection.CA.cs
@@ -15,7 +15,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
-
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
 
@@ -61,9 +61,9 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            var loggedInUser = sessionHandler.GetSessionUser();
             int observationId = 0;
             using (OracleCommand cmd = con.CreateCommand())
                 {
@@ -84,6 +84,11 @@ namespace AIS.Controllers
 
         public void CASubmitToHeadFAD(int observationId)
             {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -98,6 +103,11 @@ namespace AIS.Controllers
 
         public void CAAssignToDivision(int observationId, int divisionId)
             {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -113,6 +123,11 @@ namespace AIS.Controllers
 
         public void CAAssignToDepartment(int observationId, int departmentId)
             {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -132,9 +147,9 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            var loggedInUser = sessionHandler.GetSessionUser();
             using (OracleCommand cmd = con.CreateCommand())
                 {
                 cmd.CommandText = "PKG_CA.DEPARTMENT_RESPONSE";
@@ -150,6 +165,11 @@ namespace AIS.Controllers
 
         public void CAReviewAndForward(int observationId, string action, string remarks)
             {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -166,6 +186,11 @@ namespace AIS.Controllers
 
         public void CARejectOrReferBack(int observationId, string remarks)
             {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -181,6 +206,11 @@ namespace AIS.Controllers
 
         public void CAFinalizeObservation(int observationId)
             {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -195,6 +225,11 @@ namespace AIS.Controllers
 
         public void CAEnterLegacyObservation(HttpRequest request)
             {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var form = request.Form;
             var con = this.DatabaseConnection();
             con.Open();

--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -14,12 +14,12 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
 
             var list = new List<AuditEmployeeModel>();
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_GetAuditEmployees";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -44,17 +44,23 @@ namespace AIS.Controllers
                         }
                     }
                 }
+            con.Close();
             }
             return list;
         }
 
         public List<IdNameModel> GetRelationTypes()
         {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
+
             var list = new List<IdNameModel>();
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_GetRelationTypes";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -71,17 +77,23 @@ namespace AIS.Controllers
                         }
                     }
                 }
+            con.Close();
             }
             return list;
         }
 
         public List<IdNameModel> GetReportingOffices(int relationTypeId)
         {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
+
             var list = new List<IdNameModel>();
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_GetReportingOffices";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -99,17 +111,23 @@ namespace AIS.Controllers
                         }
                     }
                 }
+            con.Close();
             }
             return list;
         }
 
         public List<EntityModel> GetEntitiesForOffice(int reportingOfficeId)
         {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
+
             var list = new List<EntityModel>();
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_GetEntitiesForOffice";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -129,17 +147,22 @@ namespace AIS.Controllers
                         }
                     }
                 }
+            con.Close();
             }
             return list;
         }
 
         public string AllocateEntityToAuditor(int azId, int entId, int auditorPPNO)
         {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
             string resp = string.Empty;
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_allocate_entity_to_auditor";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -151,17 +174,23 @@ namespace AIS.Controllers
                     cmd.ExecuteNonQuery();
                     resp = cmd.Parameters["io_msg"].Value?.ToString();
                 }
+            con.Close();
             }
             return resp;
         }
 
         public List<ObservationReferenceModel> GetObservationsForReferenceUpdate(int? entId, int? assignedAuditorId, int? referenceId)
         {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
+
             var list = new List<ObservationReferenceModel>();
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_GetObservationsForReferenceUpdate";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -186,17 +215,22 @@ namespace AIS.Controllers
                         }
                     }
                 }
+            con.Close();
             }
             return list;
         }
 
         public string UpdateParaReference(int comId, int newRef)
         {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
             string resp = string.Empty;
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_update_para_reference";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -207,17 +241,23 @@ namespace AIS.Controllers
                     cmd.ExecuteNonQuery();
                     resp = cmd.Parameters["io_msg"].Value?.ToString();
                 }
+            con.Close();
             }
             return resp;
         }
 
         public List<UpdateLogModel> GetUpdateLog(int comId)
         {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
+
             var list = new List<UpdateLogModel>();
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_get_update_log";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -239,17 +279,23 @@ namespace AIS.Controllers
                         }
                     }
                 }
+            con.Close();
             }
             return list;
         }
 
         public List<ReferenceSearchResultModel> SearchReferences(string referenceType, string keyword)
         {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session;
+            sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection();
+            con.Open();
+
             var list = new List<ReferenceSearchResultModel>();
-            using (var con = this.DatabaseConnection())
-            {
-                con.Open();
-                using (var cmd = con.CreateCommand())
+            using (var cmd = con.CreateCommand())
                 {
                     cmd.CommandText = "PKG_FAD.P_SearchReferences";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -269,6 +315,7 @@ namespace AIS.Controllers
                         }
                     }
                 }
+            con.Close();
             }
             return list;
         }

--- a/AIS/AIS/DBConnection.IID.cs
+++ b/AIS/AIS/DBConnection.IID.cs
@@ -13,6 +13,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -40,6 +41,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -64,6 +66,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -88,6 +91,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -115,6 +119,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -139,6 +144,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -164,6 +170,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -195,6 +202,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -222,6 +230,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -246,6 +255,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())
@@ -277,6 +287,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
             using (OracleCommand cmd = con.CreateCommand())


### PR DESCRIPTION
## Summary
- initialize `SessionHandler` and DB connections consistently across partial classes
- acquire logged in user before database calls

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872829e614c832e87e97e3b1a2898be