### PR TITLE
Fix bracing in DBConnection.FAD partial class

### DIFF
--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -45,7 +45,6 @@ namespace AIS.Controllers
                     }
                 }
             con.Close();
-            }
             return list;
         }
 
@@ -78,7 +77,6 @@ namespace AIS.Controllers
                     }
                 }
             con.Close();
-            }
             return list;
         }
 
@@ -112,7 +110,6 @@ namespace AIS.Controllers
                     }
                 }
             con.Close();
-            }
             return list;
         }
 
@@ -148,7 +145,6 @@ namespace AIS.Controllers
                     }
                 }
             con.Close();
-            }
             return list;
         }
 
@@ -175,7 +171,6 @@ namespace AIS.Controllers
                     resp = cmd.Parameters["io_msg"].Value?.ToString();
                 }
             con.Close();
-            }
             return resp;
         }
 
@@ -216,7 +211,6 @@ namespace AIS.Controllers
                     }
                 }
             con.Close();
-            }
             return list;
         }
 
@@ -242,7 +236,6 @@ namespace AIS.Controllers
                     resp = cmd.Parameters["io_msg"].Value?.ToString();
                 }
             con.Close();
-            }
             return resp;
         }
 
@@ -280,7 +273,6 @@ namespace AIS.Controllers
                     }
                 }
             con.Close();
-            }
             return list;
         }
 
@@ -316,7 +308,6 @@ namespace AIS.Controllers
                     }
                 }
             con.Close();
-            }
             return list;
         }
     }


### PR DESCRIPTION
## Summary
- repair extra closing braces in `DBConnection.FAD.cs`

## Testing
- `python3 - <<'EOF'
import re
path='AIS/AIS/DBConnection.FAD.cs'
text=open(path).read()
clean=re.sub(r'//.*','',text)
clean=re.sub(r'/\*.*?\*/','',clean,flags=re.S)
clean=re.sub(r'".*?"','""',clean)
count=0
for line in clean.splitlines():
    count+=line.count('{')-line.count('}')
assert count==0
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_68729ee93560832eaa6d32f2965f49b7