### PR TITLE
Fix missing GetInt32 extension in Razor views

### DIFF
--- a/AIS/AIS/Views/_ViewImports.cshtml
+++ b/AIS/AIS/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
-﻿@using AIS
+@using AIS
 @using AIS.Models
+@using Microsoft.AspNetCore.Http
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
## Summary
- add `Microsoft.AspNetCore.Http` to `_ViewImports` so Razor pages can use `ISession` extension methods

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6872b445421c832eb10691f2feb5600a