### PR TITLE
Add circular document bulk upload

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3356,6 +3356,45 @@ namespace AIS.Controllers
             return Ok("File uploaded successfully!");
             }
 
+        [HttpPost]
+        public IActionResult UploadCircularFiles(int circularId, List<IFormFile> files)
+            {
+            if (files == null || files.Count == 0)
+                return BadRequest("No files uploaded.");
+            var db = new DBConnection();
+            var uploadedBy = User.Identity?.Name ?? "anonymous";
+            int successCount = 0;
+            foreach (var file in files)
+                {
+                using (var ms = new MemoryStream())
+                    {
+                    file.CopyTo(ms);
+                    string status;
+                    db.InsertCircularDoc(
+                        circularId,
+                        file.FileName,
+                        file.ContentType,
+                        file.Length,
+                        ms.ToArray(),
+                        uploadedBy,
+                        out status
+                    );
+                    if (status != null && status.StartsWith("Success"))
+                        successCount++;
+                    }
+                }
+            return Ok($"{successCount} file(s) uploaded successfully.");
+            }
+
+        [HttpGet]
+        public IActionResult DownloadCircularFileFromDb(int docId)
+            {
+            var db = new DBConnection();
+            var doc = db.GetCircularDocument(docId);
+            if (doc == null || doc.FileBlob == null) return NotFound();
+            return File(doc.FileBlob, doc.FileType ?? "application/octet-stream", doc.FileName);
+            }
+
 
         [HttpPost]
         public string AllocateEntitiesToAuditor(int azId, int entId, int auditorPPNO)

--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -1,5 +1,6 @@
 using AIS.Models;
 using Oracle.ManagedDataAccess.Client;
+using Oracle.ManagedDataAccess.Types;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -35,6 +36,69 @@ namespace AIS.Controllers
                     return cmd.Parameters["o_status"].Value?.ToString();
                 }
             }
+        }
+
+        public void InsertCircularDoc(
+            int circularId,
+            string fileName,
+            string fileType,
+            long fileSize,
+            byte[] fileBlob,
+            string uploadedBy,
+            out string status)
+        {
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "PKG_FAD.P_InsertCircularDoc";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_circular_id", OracleDbType.Int32).Value = circularId;
+                    cmd.Parameters.Add("p_file_name", OracleDbType.Varchar2).Value = fileName;
+                    cmd.Parameters.Add("p_file_type", OracleDbType.Varchar2).Value = fileType;
+                    cmd.Parameters.Add("p_file_size", OracleDbType.Int32).Value = fileSize;
+                    cmd.Parameters.Add("p_file_blob", OracleDbType.Blob).Value = fileBlob;
+                    cmd.Parameters.Add("p_uploaded_by", OracleDbType.Varchar2).Value = uploadedBy;
+                    cmd.Parameters.Add("o_status", OracleDbType.Varchar2, 200).Direction = ParameterDirection.Output;
+                    cmd.ExecuteNonQuery();
+                    status = cmd.Parameters["o_status"].Value?.ToString();
+                }
+            }
+        }
+
+        public CircularDocumentModel GetCircularDocument(int docId)
+        {
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "PKG_FAD.P_GetCircularDoc";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_doc_id", OracleDbType.Int32).Value = docId;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        if (rdr.Read())
+                        {
+                            return new CircularDocumentModel
+                            {
+                                DocId = docId,
+                                CircularId = rdr["CIRCULAR_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["CIRCULAR_ID"]),
+                                FileName = rdr["FILE_NAME"].ToString(),
+                                FileType = rdr["FILE_TYPE"].ToString(),
+                                FileSize = rdr["FILE_SIZE"] == DBNull.Value ? 0 : Convert.ToInt64(rdr["FILE_SIZE"]),
+                                FileBlob = rdr["FILE_BLOB"] == DBNull.Value ? null : ((OracleBlob)rdr.GetOracleBlob(rdr.GetOrdinal("FILE_BLOB"))).Value,
+                                UploadedBy = rdr["UPLOADED_BY"].ToString(),
+                                UploadedOn = rdr["UPLOADED_ON"] == DBNull.Value ? DateTime.MinValue : Convert.ToDateTime(rdr["UPLOADED_ON"])
+                            };
+                        }
+                    }
+                }
+            }
+            return null;
         }
             
 

--- a/AIS/AIS/Views/FAD/Upload_Circular_Document.cshtml
+++ b/AIS/AIS/Views/FAD/Upload_Circular_Document.cshtml
@@ -3,40 +3,26 @@
     Layout = "_Layout";
 }
 
-<h4>Upload Circular Document (PDF/JPEG)</h4>
+<h4>Upload Circular Documents (PDF/JPEG)</h4>
 <form id="uploadForm" enctype="multipart/form-data">
-    <div class="mb-2">
-        <label for="circularId">Select Circular:</label>
-        <select class="form-select" id="circularId" name="circularId" required>
-            <option value="">-- Select --</option>
-            @foreach (var c in ViewBag.Circulars as List<SelectListItem>)
-            {
-                <option value="@c.Value">@c.Text</option>
-            }
-        </select>
-    </div>
-    <div class="mb-2">
-        <label for="file">Select PDF or JPEG:</label>
-        <input type="file" class="form-control" id="file" name="file" accept=".pdf,.jpg,.jpeg" required />
-    </div>
+    <input type="number" id="circularId" name="circularId" required placeholder="Circular ID" class="form-control mb-2" />
+    <input type="file" id="files" name="files" multiple accept=".pdf,.jpg,.jpeg" required class="form-control mb-2" />
     <button class="btn btn-primary" type="submit">Upload</button>
 </form>
-
-<div id="resultMsg" class="mt-3"></div>
-
+<div id="result" class="mt-3"></div>
 @section Scripts {
     <script>
         $("#uploadForm").submit(function(e){
             e.preventDefault();
             var formData = new FormData(this);
             $.ajax({
-                url: "/ApiCalls/UploadCircularFile",
+                url: "/ApiCalls/UploadCircularFiles",
                 type: "POST",
                 data: formData,
                 processData: false,
                 contentType: false,
-                success: function(resp){ $("#resultMsg").html('<span class="text-success">'+resp+'</span>'); },
-                error: function(xhr){ $("#resultMsg").html('<span class="text-danger">'+xhr.responseText+'</span>'); }
+                success: function(resp){ $("#result").html('<span class="text-success">'+resp+'</span>'); },
+                error: function(xhr){ $("#result").html('<span class="text-danger">'+xhr.responseText+'</span>'); }
             });
         });
     </script>


### PR DESCRIPTION
## Summary
- implement bulk circular file upload API and download API
- add DB helper methods for circular documents
- update bulk upload view for multiple files

## Testing
- `dotnet build AIS/AIS/AIS.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68751db25e28832eb16440f51247049f