### PR TITLE
Fix session usage in circular upload

### DIFF
--- a/AIS/AIS/Controllers/FADController.cs
+++ b/AIS/AIS/Controllers/FADController.cs
@@ -451,12 +451,23 @@ namespace AIS.Controllers
 
         public IActionResult Upload_Circular_Document()
             {
-            var db = new DBConnection();
-            var circulars = db.GetAuditChecklistAnnexureCirculars();
-            ViewBag.Circulars = circulars
-                .Select(c => new SelectListItem { Value = c.ID.ToString(), Text = c.InstructionsTitle })
-                .ToList();
-            return View();
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            if (!sessionHandler.IsUserLoggedIn())
+                return RedirectToAction("Index", "Login");
+            else
+                {
+                if (!sessionHandler.HasPermissionToViewPage(MethodBase.GetCurrentMethod().Name))
+                    return RedirectToAction("Index", "PageNotFound");
+                else
+                    {
+                    var circulars = dBConnection.GetAuditChecklistAnnexureCirculars();
+                    ViewBag.Circulars = circulars
+                        .Select(c => new SelectListItem { Value = c.ID.ToString(), Text = c.InstructionsTitle })
+                        .ToList();
+                    return View();
+                    }
+                }
             }
 
         public IActionResult Error()


### PR DESCRIPTION
## Summary
- ensure Upload_Circular_Document checks login and permissions
- reuse injected DBConnection instead of new instance

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875d2446148832ea51f1343527aafbe