### PR TITLE
Fix session initialization for circular upload

### DIFF
--- a/AIS/AIS/Controllers/FADController.cs
+++ b/AIS/AIS/Controllers/FADController.cs
@@ -452,6 +452,9 @@ namespace AIS.Controllers
         public IActionResult Upload_Circular_Document()
             {
             var db = new DBConnection();
+            db._httpCon = sessionHandler._httpCon;
+            db._session = sessionHandler._session;
+            db._configuration = sessionHandler._configuration;
             var circulars = db.GetAuditChecklistAnnexureCirculars();
             ViewBag.Circulars = circulars
                 .Select(c => new SelectListItem { Value = c.ID.ToString(), Text = c.InstructionsTitle })


### PR DESCRIPTION
## Summary
- fix session handler usage in `Upload_Circular_Document`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875d2446148832ea51f1343527aafbe