### PR TITLE
Add pending para API and task summary view

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3428,6 +3428,21 @@ namespace AIS.Controllers
             return dBConnection.SearchReferences(referenceType, keyword);
             }
 
+        [HttpGet]
+        public JsonResult GetPendingParas(int entityId, int auditYear)
+            {
+            var list = dBConnection.GetPendingParas(entityId, auditYear);
+            return Json(list);
+            }
+
+        [HttpGet]
+        public JsonResult GetEntityTaskSummary()
+            {
+            var user = sessionHandler.GetSessionUser();
+            var list = dBConnection.GetEntityTaskSummary(user.PPNumber);
+            return Json(list);
+            }
+
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public IActionResult Error()
             {

--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -455,5 +455,69 @@ namespace AIS.Controllers
             con.Close();
             return list;
         }
+
+        public List<PendingParaModel> GetPendingParas(int entityId, int auditYear)
+        {
+            var list = new List<PendingParaModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "PKG_FAD.P_GetPendingParas";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_entity_id", OracleDbType.Int32).Value = entityId;
+                    cmd.Parameters.Add("p_audit_year", OracleDbType.Int32).Value = auditYear;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            list.Add(new PendingParaModel
+                            {
+                                ParaId = Convert.ToInt32(rdr["PARA_ID"]),
+                                AuditYear = Convert.ToInt32(rdr["AUDIT_YEAR"]),
+                                ParaNo = rdr["PARA_NO"].ToString(),
+                                Gist = rdr["GIST"].ToString(),
+                                Risk = rdr["RISK"].ToString()
+                            });
+                        }
+                    }
+                }
+            }
+            return list;
+        }
+
+        public List<EntityTaskSummaryModel> GetEntityTaskSummary(int auditorPpno)
+        {
+            var list = new List<EntityTaskSummaryModel>();
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "PKG_FAD.P_GetEntityTaskSummary";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_auditor_ppno", OracleDbType.Int32).Value = auditorPpno;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        while (rdr.Read())
+                        {
+                            list.Add(new EntityTaskSummaryModel
+                            {
+                                EntityId = Convert.ToInt32(rdr["ENTITY_ID"]),
+                                EntityCode = rdr["ENTITY_CODE"].ToString(),
+                                EntityName = rdr["ENTITY_NAME"].ToString(),
+                                AuditYear = Convert.ToInt32(rdr["AUDIT_YEAR"]),
+                                TotalParas = Convert.ToInt32(rdr["TOTAL_PARAS"]),
+                                ParasUpdated = Convert.ToInt32(rdr["PARAS_UPDATED"])
+                            });
+                        }
+                    }
+                }
+            }
+            return list;
+        }
     }
 }

--- a/AIS/AIS/Models/EntityTaskSummaryModel.cs
+++ b/AIS/AIS/Models/EntityTaskSummaryModel.cs
@@ -1,0 +1,12 @@
+namespace AIS.Models
+{
+    public class EntityTaskSummaryModel
+    {
+        public int EntityId { get; set; }
+        public string EntityCode { get; set; }
+        public string EntityName { get; set; }
+        public int AuditYear { get; set; }
+        public int TotalParas { get; set; }
+        public int ParasUpdated { get; set; }
+    }
+}

--- a/AIS/AIS/Models/PendingParaModel.cs
+++ b/AIS/AIS/Models/PendingParaModel.cs
@@ -1,0 +1,11 @@
+namespace AIS.Models
+{
+    public class PendingParaModel
+    {
+        public int ParaId { get; set; }
+        public int AuditYear { get; set; }
+        public string ParaNo { get; set; }
+        public string Gist { get; set; }
+        public string Risk { get; set; }
+    }
+}

--- a/AIS/AIS/Views/FAD/ReferenceUpdateList.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateList.cshtml
@@ -2,18 +2,89 @@
     ViewData["Title"] = "Reference Update";
     Layout = "_Layout";
 }
-<h4>Observations Assigned</h4>
-<table class="table" id="obsTable">
-    <thead><tr><th>Entity</th><th>Para</th><th>Action</th></tr></thead>
+<h4>Reference Update Tasks</h4>
+<table id="summaryTable" class="table table-bordered table-striped">
+    <thead class="table-success">
+        <tr>
+            <th>Entity Code</th>
+            <th>Entity Name</th>
+            <th>Audit Year</th>
+            <th>Total Paras</th>
+            <th>Paras Updated</th>
+            <th>Pendency</th>
+            <th>Action</th>
+        </tr>
+    </thead>
     <tbody></tbody>
 </table>
+
+<div class="modal fade" id="pendingParasModal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Pending Paras</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <table id="pendingParasTable" class="table table-bordered">
+                    <thead class="table-info">
+                        <tr>
+                            <th>Audit Year</th>
+                            <th>Para No</th>
+                            <th>Gist</th>
+                            <th>Risk</th>
+                            <th>Action</th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
 <script>
 $(function(){
-    $.post(g_asiBaseURL+'/ApiCalls/GetObservationsForReferenceUpdate',{},function(d){
-        var body=$('#obsTable tbody');
-        $.each(d,function(i,it){
-            body.append('<tr><td>'+it.entId+'</td><td>'+it.paraTitle+'</td><td><a href="'+g_asiBaseURL+'/FAD/ReferenceUpdateEdit?comId='+it.comId+'">Assign Reference</a></td></tr>');
+    loadSummary();
+});
+
+function loadSummary(){
+    $.get(g_asiBaseURL + '/ApiCalls/GetEntityTaskSummary', function(data){
+        var body = $('#summaryTable tbody');
+        body.empty();
+        $.each(data, function(i,item){
+            var pend = item.totalParas - item.parasUpdated;
+            body.append('<tr>'+
+                '<td>'+item.entityCode+'</td>'+
+                '<td>'+item.entityName+'</td>'+
+                '<td>'+item.auditYear+'</td>'+
+                '<td>'+item.totalParas+'</td>'+
+                '<td>'+item.parasUpdated+'</td>'+
+                '<td>'+pend+'</td>'+
+                '<td><button class="btn btn-primary btn-sm" onclick="loadPendingParas('+item.entityId+','+item.auditYear+')">Assign Reference</button></td>'+
+                '</tr>');
         });
     });
-});
+}
+
+function loadPendingParas(entityId, auditYear){
+    $.get(g_asiBaseURL + '/ApiCalls/GetPendingParas',{ entityId: entityId, auditYear: auditYear },function(data){
+        var tbody = $('#pendingParasTable tbody');
+        tbody.empty();
+        $.each(data,function(i,para){
+            tbody.append('<tr>'+
+                '<td>'+para.auditYear+'</td>'+
+                '<td>'+para.paraNo+'</td>'+
+                '<td>'+para.gist+'</td>'+
+                '<td>'+para.risk+'</td>'+
+                '<td><button class="btn btn-success btn-sm" onclick="openReferenceModal('+para.paraId+')">Assign Reference</button></td>'+
+                '</tr>');
+        });
+        $('#pendingParasModal').modal('show');
+    });
+}
+
+function openReferenceModal(paraId){
+    window.location.href = g_asiBaseURL + '/FAD/ReferenceUpdateEdit?comId=' + paraId;
+}
 </script>


### PR DESCRIPTION
## Summary
- create `EntityTaskSummaryModel` and `PendingParaModel`
- expose APIs for fetching auditor task summaries and pending paras
- implement DBConnection methods using `PKG_FAD` procedures
- redesign `ReferenceUpdateList` view to show entity summary and modal for pending paras

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875e5babdd8832e94d7f388634942a1