### PR TITLE
Fix complaint form refresh and add assessment table

### DIFF
--- a/AIS/AIS/Controllers/IIDController.cs
+++ b/AIS/AIS/Controllers/IIDController.cs
@@ -92,6 +92,8 @@ namespace AIS.Controllers
             if (!sessionHandler.IsUserLoggedIn())
                 return RedirectToAction("Index", "Login");
             ViewData["ReportId"] = reportId;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            ViewData["UserId"] = loggedInUser.ID;
             return View("../IID/Analysis");
             }
 

--- a/AIS/AIS/Views/IID/Analysis.cshtml
+++ b/AIS/AIS/Views/IID/Analysis.cshtml
@@ -2,36 +2,88 @@
     ViewData["Title"] = "Analysis";
     Layout = "_Layout";
     var reportId = ViewData["ReportId"];
+    var userId = ViewData["UserId"];
 }
 <h4>Analysis</h4>
-<form id="analysisForm">
-    <input type="hidden" name="ReportId" value="@reportId" />
-    <div class="mb-2">
-        <label class="form-label">Policy Gaps</label>
-        <textarea class="form-control" name="PolicyGaps"></textarea>
+
+<table id="complaintsTable" class="table table-bordered table-striped">
+    <thead class="table-success">
+        <tr>
+            <th>Complaint No</th>
+            <th>Nature</th>
+            <th>Complainant</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+</table>
+
+<!-- Assessment Modal -->
+<div class="modal fade" id="assessmentModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Initial Assessment</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="assessmentForm">
+                    <input type="hidden" name="ComplaintId" id="modalComplaintId" />
+                    <div class="mb-2">
+                        <label class="form-label">Initial Assessment</label>
+                        <textarea class="form-control" name="Assessment"></textarea>
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label">Recommendation</label>
+                        <select class="form-select" name="Recommendation">
+                            <option>Qualify</option>
+                            <option>Not Qualify</option>
+                        </select>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button id="saveAssessment" type="button" class="btn btn-primary">Save</button>
+            </div>
+        </div>
     </div>
-    <div class="mb-2">
-        <label class="form-label">Control Gaps</label>
-        <textarea class="form-control" name="ControlGaps"></textarea>
-    </div>
-    <div class="mb-2">
-        <label class="form-label">Procedural Violations</label>
-        <textarea class="form-control" name="ProceduralViolations"></textarea>
-    </div>
-    <div class="mb-2">
-        <label class="form-label">Comments / Refer Back</label>
-        <textarea class="form-control" name="Comments"></textarea>
-    </div>
-    <button type="submit" class="btn btn-primary">Forward</button>
-</form>
+</div>
 @section Scripts{
 <script>
     $(function(){
-        $('#analysisForm').on('submit', function(e){
-            e.preventDefault();
-            var data = $(this).serialize();
-            $.post(g_asiBaseURL + '/ApiCalls/AddAnalysis', data, function(){
-                alert('Analysis submitted');
+        loadComplaints();
+
+        function loadComplaints(){
+            $.post(g_asiBaseURL + '/ApiCalls/GetComplaintsByUser',{ userId: userId },function(d){
+                destroyDatatable('complaintsTable');
+                var body = $('#complaintsTable tbody');
+                body.empty();
+                $.each(d,function(i,v){
+                    if(!v.ASSESSMENT_ID || v.ASSESSMENT_ID == 0){
+                        var row = '<tr>'+
+                            '<td>'+ (v.COMPLAINT_NO || '') +'</td>'+
+                            '<td>'+ (v.NATURE || '') +'</td>'+
+                            '<td>'+ (v.COMPLAINANT || '') +'</td>'+
+                            '<td><button type="button" class="btn btn-sm btn-primary assess-btn" data-id="'+v.COMPLAINT_ID+'">Assess</button></td>'+
+                            '</tr>';
+                        body.append(row);
+                    }
+                });
+                initializeDataTable('complaintsTable');
+            });
+        }
+
+        $(document).on('click','.assess-btn',function(){
+            $('#modalComplaintId').val($(this).data('id'));
+            $('#assessmentModal').modal('show');
+        });
+
+        $('#saveAssessment').click(function(){
+            var data = $('#assessmentForm').serialize();
+            $.post(g_asiBaseURL + '/ApiCalls/AddAssessment', data, function(){
+                $('#assessmentModal').modal('hide');
+                loadComplaints();
             });
         });
     });

--- a/AIS/AIS/Views/IID/SubmitComplaint.cshtml
+++ b/AIS/AIS/Views/IID/SubmitComplaint.cshtml
@@ -177,6 +177,10 @@
                 contentType:false,
                 success: function(d){
                     alert('Complaint submitted');
+                    location.reload();
+                },
+                error: function(){
+                    alert('Error submitting complaint');
                 }
             });
         });


### PR DESCRIPTION
## Summary
- refresh Submit Complaint form only on success
- list unassessed complaints on Analysis screen
- allow assessments from modal dialog
- pass logged in user ID to analysis view

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687767ec57c0832ea4abc14be199ec5b