### PR TITLE
Implement stored procedure based FAD reference updates

### DIFF
--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -374,45 +374,27 @@ namespace AIS.Controllers
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
-            var con = this.DatabaseConnection();
-            con.Open();
             string resp = string.Empty;
-            using (var cmd = con.CreateCommand())
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
                 {
-                cmd.CommandText = "PKG_FAD.P_update_para_reference";
-                cmd.CommandType = CommandType.StoredProcedure;
-                cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
-                cmd.Parameters.Add("p_new_ref", OracleDbType.Int32).Value = newRef;
-                cmd.Parameters.Add("p_updated_by", OracleDbType.Int32).Value = loggedInUser.PPNumber;
-                cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
-                using (var rdr = cmd.ExecuteReader())
+                    cmd.CommandText = "PKG_FAD.P_UpdateReference";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("p_new_ref", OracleDbType.Int32).Value = newRef;
+                    cmd.Parameters.Add("p_user", OracleDbType.Int32).Value = loggedInUser.PPNumber;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
                     {
-                    while (rdr.Read())
-                        {
-                        resp = rdr["remarks"]?.ToString();
-                        }
+                        if (rdr.Read())
+                            resp = rdr["remarks"]?.ToString();
                     }
                 }
 
-            // mark para as reviewed
-            using (var upd = con.CreateCommand())
-            {
-                upd.CommandText = "update AIS_T_AU_POST_COMPLIANCE set REFERENCE_REVIEWED = 1 where COM_ID = :cid";
-                upd.CommandType = CommandType.Text;
-                upd.Parameters.Add("cid", OracleDbType.Int32).Value = comId;
-                upd.ExecuteNonQuery();
+                MarkParaAsReviewed(comId, loggedInUser.PPNumber);
             }
-
-            // insert log entry
-            using (var log = con.CreateCommand())
-            {
-                log.CommandText = "insert into AIS_T_PARA_REFERENCE_LOG(PPNO, COM_ID, ACTION) values(:ppno, :cid, 'UPDATE')";
-                log.CommandType = CommandType.Text;
-                log.Parameters.Add("ppno", OracleDbType.Int32).Value = loggedInUser.PPNumber;
-                log.Parameters.Add("cid", OracleDbType.Int32).Value = comId;
-                log.ExecuteNonQuery();
-            }
-            con.Close();
             return resp;
         }
 
@@ -429,7 +411,7 @@ namespace AIS.Controllers
             var list = new List<UpdateLogModel>();
             using (var cmd = con.CreateCommand())
                 {
-                    cmd.CommandText = "PKG_FAD.P_get_update_log";
+                    cmd.CommandText = "PKG_FAD.P_GetReferenceUpdateLog";
                     cmd.CommandType = CommandType.StoredProcedure;
                     cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
                     cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
@@ -593,36 +575,105 @@ namespace AIS.Controllers
         public ParaReferenceDataModel GetParaReferenceData(int comId)
         {
             var model = new ParaReferenceDataModel { References = new List<int>() };
+            model.ParaText = GetParaText(comId);
+            model.References = GetParaReferences(comId);
+            return model;
+        }
+
+        public List<int> GetParaReferences(int comId)
+        {
+            var list = new List<int>();
             using (var con = this.DatabaseConnection())
             {
                 con.Open();
                 using (var cmd = con.CreateCommand())
                 {
-                    cmd.CommandText = "select PARA_TEXT from v_get_all_para_text_for_reference where com_id=:id";
-                    cmd.CommandType = CommandType.Text;
-                    cmd.Parameters.Add("id", OracleDbType.Int32).Value = comId;
-                    using (var rdr = cmd.ExecuteReader())
-                    {
-                        if (rdr.Read())
-                            model.ParaText = rdr["PARA_TEXT"]?.ToString();
-                    }
-                }
-
-                using (var cmd = con.CreateCommand())
-                {
-                    cmd.CommandText = "select REFERENCE_ID from TBL_PARA_REFERENCE_LINKS where PARA_ID=:id";
-                    cmd.CommandType = CommandType.Text;
-                    cmd.Parameters.Add("id", OracleDbType.Int32).Value = comId;
+                    cmd.CommandText = "PKG_FAD.P_GetParaReferences";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
                     using (var rdr = cmd.ExecuteReader())
                     {
                         while (rdr.Read())
                         {
-                            model.References.Add(rdr["REFERENCE_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["REFERENCE_ID"]));
+                            list.Add(rdr["REFERENCE_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["REFERENCE_ID"]));
                         }
                     }
                 }
             }
-            return model;
+            return list;
+        }
+
+        public string GetParaText(int comId)
+        {
+            string text = string.Empty;
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "PKG_FAD.P_GetParaText";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                    {
+                        if (rdr.Read())
+                            text = rdr["PARA_TEXT"]?.ToString();
+                    }
+                }
+            }
+            return text;
+        }
+
+        private void AddReference(int comId, int refId, int ppno)
+        {
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "PKG_FAD.P_AddReference";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("p_ref_id", OracleDbType.Int32).Value = refId;
+                    cmd.Parameters.Add("p_user", OracleDbType.Int32).Value = ppno;
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        private void DeleteReference(int comId, int refId, int ppno)
+        {
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "PKG_FAD.P_DeleteReference";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("p_ref_id", OracleDbType.Int32).Value = refId;
+                    cmd.Parameters.Add("p_user", OracleDbType.Int32).Value = ppno;
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
+
+        private void MarkParaAsReviewed(int comId, int ppno)
+        {
+            using (var con = this.DatabaseConnection())
+            {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                {
+                    cmd.CommandText = "PKG_FAD.P_MarkParaAsReviewed";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("p_user", OracleDbType.Int32).Value = ppno;
+                    cmd.ExecuteNonQuery();
+                }
+            }
         }
 
         public void SaveParaReferences(int comId, List<int> references)
@@ -632,55 +683,26 @@ namespace AIS.Controllers
             sessionHandler._session = this._session;
             sessionHandler._configuration = this._configuration;
             var user = sessionHandler.GetSessionUser();
-            using (var con = this.DatabaseConnection())
+
+            var existing = GetParaReferences(comId);
+
+            foreach (var oldRef in existing)
             {
-                con.Open();
-                using (var tran = con.BeginTransaction())
+                if (!references.Contains(oldRef))
                 {
-                    using (var del = con.CreateCommand())
-                    {
-                        del.Transaction = tran;
-                        del.CommandText = "delete from TBL_PARA_REFERENCE_LINKS where PARA_ID=:pid";
-                        del.CommandType = CommandType.Text;
-                        del.Parameters.Add("pid", OracleDbType.Int32).Value = comId;
-                        del.ExecuteNonQuery();
-                    }
-
-                    foreach (var r in references)
-                    {
-                        using (var ins = con.CreateCommand())
-                        {
-                            ins.Transaction = tran;
-                            ins.CommandText = "insert into TBL_PARA_REFERENCE_LINKS(PARA_ID,REFERENCE_ID) values(:pid,:rid)";
-                            ins.CommandType = CommandType.Text;
-                            ins.Parameters.Add("pid", OracleDbType.Int32).Value = comId;
-                            ins.Parameters.Add("rid", OracleDbType.Int32).Value = r;
-                            ins.ExecuteNonQuery();
-                        }
-                    }
-
-                    using (var upd = con.CreateCommand())
-                    {
-                        upd.Transaction = tran;
-                        upd.CommandText = "update AIS_T_AU_POST_COMPLIANCE set REFERENCE_REVIEWED = 1 where COM_ID = :cid";
-                        upd.CommandType = CommandType.Text;
-                        upd.Parameters.Add("cid", OracleDbType.Int32).Value = comId;
-                        upd.ExecuteNonQuery();
-                    }
-
-                    using (var log = con.CreateCommand())
-                    {
-                        log.Transaction = tran;
-                        log.CommandText = "insert into AIS_T_PARA_REFERENCE_LOG(PPNO, COM_ID, ACTION) values(:ppno,:cid,'REVIEW')";
-                        log.CommandType = CommandType.Text;
-                        log.Parameters.Add("ppno", OracleDbType.Int32).Value = user.PPNumber;
-                        log.Parameters.Add("cid", OracleDbType.Int32).Value = comId;
-                        log.ExecuteNonQuery();
-                    }
-
-                    tran.Commit();
+                    DeleteReference(comId, oldRef, user.PPNumber);
                 }
             }
+
+            foreach (var r in references)
+            {
+                if (!existing.Contains(r))
+                {
+                    AddReference(comId, r, user.PPNumber);
+                }
+            }
+
+            MarkParaAsReviewed(comId, user.PPNumber);
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove direct SQL from reference editing logic
- use PKG_FAD procedures for getting para text and references
- add wrappers for AddReference, DeleteReference and MarkParaAsReviewed
- update UpdateParaReference to call new procedure
- keep history retrieval via `PKG_FAD.P_GetReferenceUpdateLog`

## Testing
- `dotnet build` *(fails: `bash: command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_687b69e915ac832ebc3f782d90b77b25