### PR TITLE
Fix GetReferenceEntitySummary DB call

### DIFF
--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -557,10 +557,10 @@ namespace AIS.Controllers
                 con.Open();
                 using (var cmd = con.CreateCommand())
                 {
-                    cmd.BindByName = true;
-                    cmd.CommandText = "P_GetEntityTaskSummary";
+                    cmd.CommandText = "PKG_FAD.P_GetEntityTaskSummary";
                     cmd.CommandType = CommandType.StoredProcedure;
-                    cmd.Parameters.Add(":ppno", OracleDbType.Int32).Value = loggedInUser.PPNumber;
+                    cmd.Parameters.Add("p_auditor_ppno", OracleDbType.Int32).Value = loggedInUser.PPNumber;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
                     using (var rdr = cmd.ExecuteReader())
                     {
                         while (rdr.Read())


### PR DESCRIPTION
## Summary
- fix stored procedure parameters for `GetReferenceEntitySummary`

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb0042a98832ea06d614f86f9943a