### PR TITLE
Add default option for reference type and hide fields

### DIFF
--- a/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
@@ -10,11 +10,12 @@
 
 <div id="searchSection">
     <select id="refType" class="form-select mb-2">
+        <option value="0" selected>Please select reference</option>
         <option value="Manual">Manual</option>
         <option value="Policy">Policy</option>
         <option value="Circular">Circular</option>
     </select>
-    <div id="searchInputs">
+    <div id="searchInputs" style="display:none;">
         <input id="keyword" class="form-control mb-2" placeholder="keyword" />
         <button class="btn btn-primary" id="searchBtn">Search</button>
     </div>
@@ -24,7 +25,7 @@
         <button class="btn btn-primary" id="addManualBtn">Add</button>
     </div>
 </div>
-<table class="table" id="resultTbl">
+<table class="table" id="resultTbl" style="display:none;">
     <thead>
         <tr>
             <th>TITLE</th>
@@ -94,10 +95,14 @@
                 $('#searchInputs').show();
                 $('#resultTbl').show();
                 $('#manualInputs').hide();
-            }else{
+            } else if(t === 'Manual' || t === 'Policy') {
                 $('#searchInputs').hide();
                 $('#resultTbl').hide();
                 $('#manualInputs').show();
+            } else {
+                $('#searchInputs').hide();
+                $('#resultTbl').hide();
+                $('#manualInputs').hide();
             }
         }
 


### PR DESCRIPTION
## Summary
- hide reference-related sections until a type is selected
- show placeholder option "Please select reference" in the dropdown

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd2d79850832eb4b87c8daa008b7d