### PR TITLE
Show remarks after saving references

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3440,8 +3440,8 @@ namespace AIS.Controllers
         [HttpPost]
         public IActionResult SaveParaReferences([FromBody] SaveParaReferencesRequestModel model)
             {
-            dBConnection.SaveParaReferences(model.ComId, model.References);
-            return Ok();
+            var message = dBConnection.SaveParaReferences(model.ComId, model.References);
+            return Json(message);
             }
 
         [HttpPost]

--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -717,9 +717,9 @@ namespace AIS.Controllers
         /// <c>PKG_FAD.P_ManageReference</c> procedure with the <c>ADD</c> action
         /// instead of the legacy <c>P_AddReference</c> procedure.
         /// </summary>
-        private void AddReference(ParaReferenceLinkModel link, string ppno)
+        private string AddReference(ParaReferenceLinkModel link, string ppno)
             {
-            ManageReference(
+            return ManageReference(
                 "ADD",
                 link,
                 link?.ParaId,
@@ -732,9 +732,9 @@ namespace AIS.Controllers
         /// Removes a para reference using <c>P_ManageReference</c> with the
         /// <c>DELETE</c> action.
         /// </summary>
-        private void DeleteReference(int comId, int refId, string ppno)
+        private string DeleteReference(int comId, int refId, string ppno)
             {
-            ManageReference(
+            return ManageReference(
                 "DELETE",
                 null,
                 comId,
@@ -746,7 +746,7 @@ namespace AIS.Controllers
         // reference_reviewed flag is now updated inside P_ManageReference so
         // the standalone MarkParaAsReviewed method is no longer required.
 
-        public void SaveParaReferences(int comId, List<ParaReferenceLinkModel> references)
+        public string SaveParaReferences(int comId, List<ParaReferenceLinkModel> references)
             {
             sessionHandler = new SessionHandler();
             sessionHandler._httpCon = this._httpCon;
@@ -755,12 +755,13 @@ namespace AIS.Controllers
             var user = sessionHandler.GetSessionUser();
 
             var existing = GetParaReferences(comId);
+            string lastStatus = string.Empty;
 
             foreach (var oldRef in existing)
                 {
                 if (!references.Any(r => r.ReferenceId == oldRef))
                     {
-                    DeleteReference(comId, oldRef, user.PPNumber);
+                    lastStatus = DeleteReference(comId, oldRef, user.PPNumber);
                     }
                 }
 
@@ -769,9 +770,11 @@ namespace AIS.Controllers
                 if (!existing.Contains(r.ReferenceId))
                     {
                     r.ParaId = comId;
-                    AddReference(r, user.PPNumber);
+                    lastStatus = AddReference(r, user.PPNumber);
                     }
                 }
+
+            return lastStatus;
             }
         }
     }

--- a/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
@@ -155,7 +155,8 @@
                 type: 'POST',
                 contentType: 'application/json',
                 data: JSON.stringify(payload),
-                success: function(){
+                success: function(resp){
+                    alert(resp);
                     window.location.href = g_asiBaseURL + '/FAD/ReferenceEntitySummary';
                 }
             });


### PR DESCRIPTION
## Summary
- capture the output from reference operations in `DBConnection.FAD`
- return that message from the API
- alert the message when saving para references

## Testing
- ❌ `dotnet build AIS/AIS.sln -c Release` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd70bc278832eb7b3dbf832e4cb13