### PR TITLE
Fix link id handling in reference update

### DIFF
--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -602,15 +602,71 @@ namespace AIS.Controllers
 
         public ParaReferenceDataModel GetParaReferenceData(int comId)
             {
-            var model = new ParaReferenceDataModel { References = new List<int>(), ReferenceDetails = new List<AuditChecklistAnnexureCircularModel>() };
+            var model = new ParaReferenceDataModel
+                {
+                References = new List<int>(),
+                ReferenceDetails = new List<AuditChecklistAnnexureCircularModel>(),
+                ReferenceLinks = new List<ParaReferenceLinkModel>()
+                };
+
             model.ParaText = GetParaText(comId);
-            model.References = GetParaReferences(comId);
+
+            var links = GetParaReferenceLinks(comId);
+            model.ReferenceLinks = links;
+            model.References = links.Select(l => l.ReferenceId).ToList();
 
             var allRefs = GetAuditChecklistAnnexureCirculars();
             if (model.References != null && model.References.Count > 0)
+                {
                 model.ReferenceDetails = allRefs.Where(r => model.References.Contains(r.ID)).ToList();
+                foreach (var det in model.ReferenceDetails)
+                    {
+                    var lnk = links.FirstOrDefault(l => l.ReferenceId == det.ID);
+                    if (lnk != null)
+                        det.LinkId = lnk.LinkId;
+                    }
+                }
 
             return model;
+            }
+
+        public List<ParaReferenceLinkModel> GetParaReferenceLinks(int comId)
+            {
+            var list = new List<ParaReferenceLinkModel>();
+            using (var con = this.DatabaseConnection())
+                {
+                con.Open();
+                using (var cmd = con.CreateCommand())
+                    {
+                    cmd.CommandText = "PKG_FAD.P_GetParaReferences";
+                    cmd.CommandType = CommandType.StoredProcedure;
+                    cmd.Parameters.Add("p_com_id", OracleDbType.Int32).Value = comId;
+                    cmd.Parameters.Add("io_cursor", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                    using (var rdr = cmd.ExecuteReader())
+                        {
+                        while (rdr.Read())
+                            {
+                            list.Add(new ParaReferenceLinkModel
+                                {
+                                LinkId = rdr["LINK_ID"] == DBNull.Value ? (int?)null : Convert.ToInt32(rdr["LINK_ID"]),
+                                EntityId = rdr["ENTITY_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["ENTITY_ID"]),
+                                OldParaId = rdr["OLD_PARA_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["OLD_PARA_ID"]),
+                                NewParaId = rdr["NEW_PARA_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["NEW_PARA_ID"]),
+                                ParaId = rdr["PARA_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["PARA_ID"]),
+                                ReferenceId = rdr["REFERENCE_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["REFERENCE_ID"]),
+                                ReferenceTitle = rdr["REFERENCE_TITLE"].ToString(),
+                                CreditManualId = rdr["CREDIT_MANUAL_ID"] == DBNull.Value ? (int?)null : Convert.ToInt32(rdr["CREDIT_MANUAL_ID"]),
+                                OpManualId = rdr["OP_MANUAL_ID"] == DBNull.Value ? (int?)null : Convert.ToInt32(rdr["OP_MANUAL_ID"]),
+                                ManualType = rdr["MANUAL_TYPE"].ToString(),
+                                Chapter = rdr["CHAPTER"].ToString(),
+                                MatchedText = rdr["MATCHED_TEXT"].ToString(),
+                                LinkType = rdr["LINK_TYPE"].ToString()
+                                });
+                            }
+                        }
+                    }
+                }
+            return list;
             }
 
         public List<int> GetParaReferences(int comId)
@@ -771,24 +827,26 @@ namespace AIS.Controllers
             sessionHandler._configuration = this._configuration;
             var user = sessionHandler.GetSessionUser();
 
-            var existing = GetParaReferences(comId);
+            var existing = GetParaReferenceLinks(comId);
             string result = string.Empty;
 
             foreach (var oldRef in existing)
                 {
-                if (!references.Any(r => r.ReferenceId == oldRef))
+                if (!references.Any(r => r.ReferenceId == oldRef.ReferenceId))
                     {
-                    result = DeleteReference(comId, oldRef, user.PPNumber);
+                    result = DeleteReference(comId, oldRef.ReferenceId, user.PPNumber);
                     }
                 }
 
             foreach (var r in references)
                 {
-                if (!existing.Contains(r.ReferenceId))
-                    {
-                    r.ParaId = comId;
+                var match = existing.FirstOrDefault(x => x.ReferenceId == r.ReferenceId);
+                r.ParaId = comId;
+                if (match != null)
+                    r.LinkId = match.LinkId;
+
+                if (match == null)
                     result = AddReference(r, user.PPNumber);
-                    }
                 }
 
             return string.IsNullOrEmpty(result) ? "Saved" : result;

--- a/AIS/AIS/Models/AuditChecklistAnnexureCircularModel.cs
+++ b/AIS/AIS/Models/AuditChecklistAnnexureCircularModel.cs
@@ -4,6 +4,11 @@ namespace AIS.Models
     {
     public class AuditChecklistAnnexureCircularModel
         {
+        /// <summary>
+        /// Identifier of <c>TBL_PARA_REFERENCE_LINKS</c> row when the circular
+        /// is associated with a para. Null for unlinked references.
+        /// </summary>
+        public int? LinkId { get; set; }
         public int ID { get; set; }
         public int DivisionEntId { get; set; }
         public int ReferenceTypeId { get; set; }

--- a/AIS/AIS/Models/ParaReferenceDataModel.cs
+++ b/AIS/AIS/Models/ParaReferenceDataModel.cs
@@ -7,5 +7,9 @@ namespace AIS.Models
         public string ParaText { get; set; }
         public List<int> References { get; set; }
         public List<AuditChecklistAnnexureCircularModel> ReferenceDetails { get; set; }
+        /// <summary>
+        /// Raw link records for the para.
+        /// </summary>
+        public List<ParaReferenceLinkModel> ReferenceLinks { get; set; }
     }
 }

--- a/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
@@ -44,12 +44,14 @@
         var comId = @Model;
         var refs = [];
         var refDetails = [];
+        var refLinks = [];
         var manualCounter = -1;
 
         $.get(g_asiBaseURL + '/ApiCalls/GetParaReferenceData', { comId: comId }, function(d){
             $('#paraText').html(d.paraText);
             refs = d.references || [];
             refDetails = d.referenceDetails || [];
+            refLinks = d.referenceLinks || [];
             renderRefs();
         });
 
@@ -79,7 +81,8 @@
                 instructionsDate: null,
                 referenceType: $('#refType').val(),
                 division: chap,
-                divisionEntId: 0
+                divisionEntId: 0,
+                linkId: null
             });
             $('#manualName').val('');
             $('#chapterSection').val('');
@@ -111,8 +114,10 @@
             if($.inArray(ref, refs) === -1){
                 refs.push(ref);
                 $.get(g_asiBaseURL + '/ApiCalls/GetReferenceDetail', { refId: ref }, function(d){
-                    if(d)
+                    if(d){
+                        d.linkId = null;
                         refDetails.push(d);
+                    }
                     renderRefs();
                 });
             }


### PR DESCRIPTION
## Summary
- propagate link id for para references
- expose reference link data via `GetParaReferenceLinks`
- include links in `ParaReferenceDataModel`
- ensure `ReferenceUpdateEdit` passes link ids when saving

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be70c1a50832e817b4411bfd7679d