### PR TITLE
Fix LinkId handling in reference update workflow

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3417,10 +3417,10 @@ namespace AIS.Controllers
             }
 
         [HttpPost]
-        public string UpdateParaReference(int comId, int newRef)
+        public string UpdateParaReference(int comId, int? linkId, int newRef)
             {
             var user = sessionHandler.GetSessionUser();
-            return dBConnection.UpdateParaReference(comId, newRef);
+            return dBConnection.UpdateParaReference(comId, linkId, newRef);
             }
 
         [HttpGet]

--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -369,7 +369,7 @@ namespace AIS.Controllers
             return list;
             }
 
-        public string UpdateParaReference(int comId, int newRef)
+        public string UpdateParaReference(int comId, int? linkId, int newRef)
             {
             sessionHandler = new SessionHandler();
             sessionHandler._httpCon = this._httpCon;
@@ -380,7 +380,7 @@ namespace AIS.Controllers
             // Call the unified procedure with UPDATE action
             var result = ManageReference(
                 "UPDATE",
-                null,
+                new ParaReferenceLinkModel { LinkId = linkId },
                 comId,
                 null,
                 newRef,
@@ -804,11 +804,11 @@ namespace AIS.Controllers
         /// Removes a para reference using <c>P_ManageReference</c> with the
         /// <c>DELETE</c> action.
         /// </summary>
-        private string DeleteReference(int comId, int refId, string ppno)
+        private string DeleteReference(int comId, int? linkId, int refId, string ppno)
             {
             var resp = ManageReference(
                 "DELETE",
-                null,
+                new ParaReferenceLinkModel { LinkId = linkId },
                 comId,
                 refId,
                 null,
@@ -832,21 +832,25 @@ namespace AIS.Controllers
 
             foreach (var oldRef in existing)
                 {
-                if (!references.Any(r => r.ReferenceId == oldRef.ReferenceId))
+                if (!references.Any(r => r.LinkId == oldRef.LinkId))
                     {
-                    result = DeleteReference(comId, oldRef.ReferenceId, user.PPNumber);
+                    result = DeleteReference(comId, oldRef.LinkId, oldRef.ReferenceId, user.PPNumber);
                     }
                 }
 
             foreach (var r in references)
                 {
-                var match = existing.FirstOrDefault(x => x.ReferenceId == r.ReferenceId);
+                var match = existing.FirstOrDefault(x => x.LinkId == r.LinkId);
                 r.ParaId = comId;
-                if (match != null)
-                    r.LinkId = match.LinkId;
 
                 if (match == null)
+                    {
                     result = AddReference(r, user.PPNumber);
+                    }
+                else if (match.ReferenceId != r.ReferenceId && r.LinkId.HasValue)
+                    {
+                    result = UpdateParaReference(comId, r.LinkId.Value, r.ReferenceId);
+                    }
                 }
 
             return string.IsNullOrEmpty(result) ? "Saved" : result;

--- a/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
@@ -138,8 +138,13 @@
         $('#saveBtn').click(function(){
             var payload = { comId: comId, references: [] };
             $.each(refDetails, function(i,r){
+                var lnk = r.linkId !== undefined && r.linkId !== null ? r.linkId : null;
+                if(lnk === null){
+                    var found = refLinks.find(function(fl){ return fl.referenceId === r.id; });
+                    if(found) lnk = found.linkId;
+                }
                 payload.references.push({
-                    linkId: r.linkId,
+                    linkId: lnk,
                     entityId: r.divisionEntId || 0,
                     oldParaId: 0,
                     newParaId: 0,


### PR DESCRIPTION
## Summary
- propagate linkId on the reference update page
- pass linkId through DB helper methods
- update API controller and DB logic to handle linkId when adding, deleting or updating references

## Testing
- `dotnet build AIS.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bee868df4832ea456771e937c1a64