### PR TITLE
Fix annexure dropdown selection and risk display

### DIFF
--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -233,6 +233,7 @@
         var annexId = $('#updatedAnnexlist').val();
         var riskName = '';
         g_selectedRiskId = 0;
+        g_annexureRefId = parseInt(annexId);
         $.each(g_annexList, function (i, v) {
             var id = v.ID || v.id;
             if (id == annexId) {

--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -12,6 +12,7 @@
 
     var g_selectedRiskId = 0;
     var g_annexureRefId = 0;
+    var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
     $(document).ready(function () {
         var url_string = window.location;
         var url = new URL(url_string);
@@ -58,6 +59,7 @@
             $('.richText-editor').html('');
             $('#viewMemo_heading').val('');
             $('#updatedAnnexlist').val('0');
+            g_annexureRefId = 0;
             g_selectedRiskId = 0;
             $('#viewMemo_risk_display').val('');
             $('#viewMemo_replydays').val(1);
@@ -76,6 +78,7 @@
         var annexId = $('#updatedAnnexlist').val();
         var riskName = '';
         g_selectedRiskId = 0;
+        g_annexureRefId = parseInt(annexId);
         $.each(g_annexList, function (i, v) {
             var id = v.ID || v.id;
             if (id == annexId) {
@@ -213,8 +216,8 @@
             $('#viewMemoModel').modal('show');
             $('.richText-editor').html(tempobj.MEMO);
             $('#viewMemo_heading').val(tempobj.HEADING);
-            $('#viewMemo_risk').val(tempobj.RISK);
-            $('#updatedAnnexlist').val(tempobj.ANNEXURE_ID);
+            $('#updatedAnnexlist').val(tempobj.ANNEXURE_ID).trigger('change');
+            g_annexureRefId = parseInt(tempobj.ANNEXURE_ID || tempobj.ANNEXURE_REF_ID || 0);
             $('#viewMemo_replydays').val(tempobj.DAYS);
             $('#viewMemo_loancase').val(tempobj.LOANCASE);
             $('#viewMemo_noinstances').val(tempobj.NO_OF_INSTANCES);


### PR DESCRIPTION
## Summary
- ensure Annexure dropdown loads options and risk colors correctly in Sub Checklist view
- update risk display and annexure reference id when annexure changes in CAU Observation view

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2474199c832eb63e39787349ed23