### PR TITLE
Update reference section UI and annexure logic

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -23,18 +23,21 @@
     var g_procId = 0;
     var g_subProcId=0;
     var g_procDetailId=0;
+    var g_selectedRiskId = 0;
+    var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
     $(document).ready(function () {
         $('#entitySelectField').select2();
         var entName = $('#manageObsPanel tbody .entity_name_field:first').text();
         $('#entityNameField').val(entName);
         var periodName = $('#manageObsPanel tbody .period_name_field:first').text();
         $('#auditPeriodNameField').val(periodName);
-         $('#viewMemo_memo_ObSent').richText({
+        $('#viewMemo_memo_ObSent').richText({
             imageUpload: false,
             fileUpload: false,
             videoEmbed: false,
             urls: false
         });
+        $('#viewMemo_annex_ObSent').on('change', updateRiskDisplay);
 
          document.getElementById('viewMemo_amount_ObSent').addEventListener('input', function (e) {
         this.value = this.value.replace(/\D|^0(?=\d)/g, ''); // Removes decimals and leading zeros
@@ -207,7 +210,8 @@
          $('#viewMemo_aud_reply_ObSent').html('');
          $('#viewMemo_head_reply_ObSent').html('');
          $('#viewMemo_annex_ObSent').val(0);
-         $('#viewMemo_risk_ObSent').val(0);
+         $('#viewMemo_risk_display').val('');
+         g_selectedRiskId = 0;
          $('#viewMemo_process_ObSent').val(0);
           $('#viewMemo_amount_ObSent').val(0);
          $('#viewMemo_inst_ObSent').val(0);
@@ -232,7 +236,8 @@
          ViewAuditeeAttachedEvidences();
          $('#viewMemo_aud_reply_ObSent').html(data.auditoR_RECOM);
          $('#viewMemo_annex_ObSent').val(data.annexurE_ID);
-         $('#viewMemo_risk_ObSent').val(data.riskmodeL_ID);
+         g_selectedRiskId = data.riskmodeL_ID;
+         updateRiskDisplay();
          $('#viewMemo_process_ObSent').val(data.procesS_ID);
          $('#viewMemo_amount_ObSent').val(data.amounT_INVOLVED);
          $('#viewMemo_inst_ObSent').val(data.nO_OF_INSTANCES);
@@ -281,7 +286,7 @@
         });
 
     }
-      function getCheckListDetailOfSubProcess() {
+    function getCheckListDetailOfSubProcess() {
         var processId = $('#viewMemo_process_ObSent').val();
         var subProcessId = $('#viewMemo_subprocess_ObSent').val();
         if (processId != 0 && subProcessId !=0) {
@@ -306,6 +311,28 @@
             });
         }
 
+    }
+    function updateRiskDisplay() {
+        var annexId = $('#viewMemo_annex_ObSent').val();
+        var riskName = '';
+        g_selectedRiskId = 0;
+        $.each(g_annexList, function (i, v) {
+            var id = v.ID || v.id;
+            if (id == annexId) {
+                riskName = v.RISK || v.risk;
+                g_selectedRiskId = v.RISK_ID || v.risK_ID;
+            }
+        });
+        $('#viewMemo_risk_display').val(riskName);
+        var color = '';
+        if (riskName.toLowerCase() === 'high') {
+            color = 'red';
+        } else if (riskName.toLowerCase() === 'medium') {
+            color = 'gold';
+        } else if (riskName.toLowerCase() === 'low') {
+            color = 'green';
+        }
+        $('#viewMemo_risk_display').css('color', color);
     }
     function ViewAuditeeAttachedEvidences() {
         $.ajax({
@@ -440,7 +467,7 @@
                 'PROCESS_ID': $('#viewMemo_process_ObSent').val(),
                 'SUB_PROCESS_ID': $('#viewMemo_subprocess_ObSent').val(),
                 'PROCESS_DETAIL_ID': $('#viewMemo_checklist_ObSent').val(),
-                'RISK_ID': $('#viewMemo_risk_ObSent').val(),
+                'RISK_ID': g_selectedRiskId,
                 'GIST_OF_PARA': $('#viewMemo_heading_ObSent').val(),
                 'TEXT_PARA': $('#viewMemo_memo_ObSent').val(),
                 'AMOUNT_INV': $('#viewMemo_amount_ObSent').val(),
@@ -686,20 +713,8 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="viewMemo_risk">Risk</label>
-                        <select id="viewMemo_risk_ObSent" class="form-select form-control" aria-label="Default select example">
-                            <option value="0" id="0" selected>--Select Risk Category--</option>
-                            @{
-                                if (ViewData["RiskList"] != null)
-                                {
-                                    foreach (var risk in (dynamic)(ViewData["RiskList"]))
-                                    {
-                                        <option id="@risk.R_ID" value="@risk.R_ID">@risk.DESCRIPTION</option>
-                                    }
-
-                                }
-                            }
-                        </select>
+                        <label for="viewMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
+                        <input id="viewMemo_risk_display" class="form-control" readonly />
 
 
                     </div>
@@ -711,7 +726,7 @@
                         <label for="viewMemo_memo_ObSent" class="font-weight-bold">Para Text</label>
                         <input id="viewMemo_memo_ObSent" type="text" class="form-control" />
                     </div>
-                    <div id="referenceSection" class="mt-3">
+                    <div id="referenceSection" class="mt-3 border p-3">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <div id="searchSection" style="display:none;"></div>

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -23,6 +23,8 @@
     var g_annexId = 0;
     var g_currentStatus = 0;
     var g_obsList = [];
+    var g_selectedRiskId = 0;
+    var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
     $(document).ready(function () {
         $('#entitySelectField').select2();
         var entName = $('#manageObsPanel tbody .entity_name_field:first').text();
@@ -36,6 +38,7 @@
             videoEmbed: false,
             urls: false
         });
+        $('#updateMemo_annex').on('change', updateRiskDisplay);
     });
     function reloadLocation() {
         getEntityObservation();
@@ -123,6 +126,28 @@
         }
 
 
+    }
+    function updateRiskDisplay() {
+        var annexId = $('#updateMemo_annex').val();
+        var riskName = '';
+        g_selectedRiskId = 0;
+        $.each(g_annexList, function (i, v) {
+            var id = v.ID || v.id;
+            if (id == annexId) {
+                riskName = v.RISK || v.risk;
+                g_selectedRiskId = v.RISK_ID || v.risK_ID;
+            }
+        });
+        $('#updateMemo_risk_display').val(riskName);
+        var color = '';
+        if (riskName.toLowerCase() === 'high') {
+            color = 'red';
+        } else if (riskName.toLowerCase() === 'medium') {
+            color = 'gold';
+        } else if (riskName.toLowerCase() === 'low') {
+            color = 'green';
+        }
+        $('#updateMemo_risk_display').css('color', color);
     }
     function ObservationViewerPanel(obs_id, status_id, risk_id, anxId) {
         g_obsId = obs_id;
@@ -231,8 +256,9 @@
                 $('#updateMemoContent').val(data[0].obS_TEXT).trigger('change');
                 $('#updateMemo_heading').val(data[0].heading);
                 $('#updateMemo_process').val(data[0].procesS_ID);
-                $('#updateMemo_risk').val(data[0].obS_RISK_ID);
                 $('#updateMemo_annex').val(data[0].annexurE_ID);
+                g_selectedRiskId = data[0].obS_RISK_ID;
+                updateRiskDisplay();
                 $('#updateMemo_subprocess').empty();
                 $('#updateMemo_subprocess').append('<option value="0">' + data[0].suB_PROCESS + '</option>');
                 $('#updateMemo_violation').empty();
@@ -394,6 +420,7 @@
     }
     function finalUpdateMemoContent(obs_id) {
         g_obsId = obs_id;
+        updateRiskDisplay();
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/update_observation_text",
             type: "POST",
@@ -402,7 +429,7 @@
                 'OBS_TITLE': $('#updateMemo_heading').val(),
                 'OBS_TEXT': $('.richText-editor').html(),
                 'ANNEXURE_ID': $('#updateMemo_annex').val(),
-                'RISK_ID': $('#updateMemo_risk').val(),
+                'RISK_ID': g_selectedRiskId,
                 'PROCESS_ID': $('#updateMemo_process').val(),
                 'SUBPROCESS_ID': $('#updateMemo_subprocess').val(),
                 'CHECKLIST_ID': $('#updateMemo_violation').val()
@@ -609,7 +636,7 @@
                         <label for="viewMemo_memo" class="font-weight-bold">Memo</label>
                         <div id="viewMemo_memo" disabled="disabled" style="height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div id="referenceSection" class="mt-3">
+                    <div id="referenceSection" class="mt-3 border p-3">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <button class="btn btn-success mb-3" id="saveBtn">Save</button>
@@ -772,7 +799,7 @@
 
                         </textarea>
                     </div>
-                    <div id="referenceSection" class="mt-3">
+                    <div id="referenceSection" class="mt-3 border p-3">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <button class="btn btn-success mb-3" id="saveBtn">Save</button>
@@ -808,21 +835,8 @@
                         </table>
                     </div>
                     <div class="form-group">
-                        <label for="updateMemo_risk">Risk</label>
-                        <select id="updateMemo_risk" class="form-select form-control" aria-label="Default select example">
-                            <option value="0" id="0" selected>--Select Risk Category--</option>
-                            @{
-                                if (ViewData["RiskList"] != null)
-                                {
-
-                                    foreach (var risk in (dynamic)(ViewData["RiskList"]))
-                                    {
-                                        <option id="@risk.R_ID" value="@risk.R_ID">@risk.DESCRIPTION</option>
-                                    }
-
-                                }
-                            }
-                        </select>
+                        <label for="updateMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
+                        <input id="updateMemo_risk_display" class="form-control" readonly />
                     </div>
 
                 </form>

--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -4,11 +4,13 @@
 }
 <script type="text/javascript">
     var g_observationId = 0;
-     var g_engId = 0;
-     var g_respUsersArr = [];
-        var g_procId = 0;
-      var g_subProcId=0;
-      var g_procDetailId=0;
+    var g_engId = 0;
+    var g_respUsersArr = [];
+    var g_procId = 0;
+    var g_subProcId = 0;
+    var g_procDetailId = 0;
+    var g_selectedRiskId = 0;
+    var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
 
     $(document).ready(function () {
         $('#preConcludingActionHandler').addClass("d-none");
@@ -18,6 +20,7 @@
              videoEmbed: false,
              urls: false
          });
+        $('#viewMemo_annex_ObSent').on('change', updateRiskDisplay);
 
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/GetReferenceTypes",
@@ -118,7 +121,8 @@
             $('#viewMemo_head_reply_ObSent').html('');
            $('#viewMemo_head_reply_ObSent').html('');
            $('#viewMemo_annex_ObSent').val(0);
-           $('#viewMemo_risk_ObSent').val(0);
+           $('#viewMemo_risk_display').val('');
+           g_selectedRiskId = 0;
            $('#viewMemo_process_ObSent').val(0);
             $('#viewMemo_amount_ObSent').val(0);
            $('#viewMemo_inst_ObSent').val(0);
@@ -141,7 +145,8 @@
            $('#viewMemo_aud_reply_ObSent').html(data.auditoR_RECOM);
             $('#viewMemo_head_reply_ObSent').html(data.heaD_RECOM);
            $('#viewMemo_annex_ObSent').val(data.annexurE_ID);
-           $('#viewMemo_risk_ObSent').val(data.riskmodeL_ID);
+           g_selectedRiskId = data.riskmodeL_ID;
+           updateRiskDisplay();
            $('#viewMemo_process_ObSent').val(data.procesS_ID);
            $('#viewMemo_paraNo_ObSent').val(data.finaL_PARA_NO);
            $('#viewMemo_amount_ObSent').val(data.amounT_INVOLVED);
@@ -195,7 +200,7 @@
           });
 
       }
-        function getCheckListDetailOfSubProcess() {
+      function getCheckListDetailOfSubProcess() {
           var processId = $('#viewMemo_process_ObSent').val();
           var subProcessId = $('#viewMemo_subprocess_ObSent').val();
           if (processId != 0 && subProcessId !=0) {
@@ -220,6 +225,29 @@
               });
           }
 
+      }
+
+      function updateRiskDisplay() {
+          var annexId = $('#viewMemo_annex_ObSent').val();
+          var riskName = '';
+          g_selectedRiskId = 0;
+          $.each(g_annexList, function (i, v) {
+              var id = v.ID || v.id;
+              if (id == annexId) {
+                  riskName = v.RISK || v.risk;
+                  g_selectedRiskId = v.RISK_ID || v.risK_ID;
+              }
+          });
+          $('#viewMemo_risk_display').val(riskName);
+          var color = '';
+          if (riskName.toLowerCase() === 'high') {
+              color = 'red';
+          } else if (riskName.toLowerCase() === 'medium') {
+              color = 'gold';
+          } else if (riskName.toLowerCase() === 'low') {
+              color = 'green';
+          }
+          $('#viewMemo_risk_display').css('color', color);
       }
         function ViewAuditeeAttachedEvidences() {
           $.ajax({
@@ -354,7 +382,7 @@
                   'PROCESS_ID': $('#viewMemo_process_ObSent').val(),
                   'SUB_PROCESS_ID': $('#viewMemo_subprocess_ObSent').val(),
                   'PROCESS_DETAIL_ID': $('#viewMemo_checklist_ObSent').val(),
-                  'RISK_ID': $('#viewMemo_risk_ObSent').val(),
+                  'RISK_ID': g_selectedRiskId,
                   'GIST_OF_PARA': $('#viewMemo_heading_ObSent').val(),
                   'TEXT_PARA': $('#viewMemo_memo_ObSent').val(),
                   'AMOUNT_INV': $('#viewMemo_amount_ObSent').val(),
@@ -590,21 +618,8 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="viewMemo_risk">Risk</label>
-                        <select id="viewMemo_risk_ObSent" class="form-select form-control" disabled aria-label="Default select example">
-                            <option value="0" id="0" selected>--Select Risk Category--</option>
-                            @{
-                                if (ViewData["RiskList"] != null)
-                                {
-
-                                    foreach (var risk in (dynamic)(ViewData["RiskList"]))
-                                    {
-                                        <option id="@risk.R_ID" value="@risk.R_ID">@risk.DESCRIPTION</option>
-                                    }
-
-                                }
-                            }
-                        </select>
+                        <label for="viewMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
+                        <input id="viewMemo_risk_display" class="form-control" readonly />
 
                     <div class="form-group">
                         <label for="viewMemo_paraNo_ObSent" class="font-weight-bold">Para No</label>
@@ -642,7 +657,7 @@
                         <label for="viewMemo_memo_ObSent" class="font-weight-bold">Para Text</label>
                         <input id="viewMemo_memo_ObSent" type="text" class="form-control" />
                     </div>
-                    <div id="referenceSection" class="mt-3">
+                    <div id="referenceSection" class="mt-3 border p-3">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <button class="btn btn-success mb-3" id="saveBtn">Save</button>


### PR DESCRIPTION
## Summary
- add annexure-based risk display logic to observation update forms
- wrap reference sections with bordered boxes
- replace risk dropdowns with annexure driven risk display inputs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed9e0fafc832ea3c59f0121966eba