### PR TITLE
Fix view borders and markup

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -667,7 +667,7 @@
             </div>
             <div class="modal-body">
                 <form>
-                    <div class="form-group" style="border:1px solid red;padding:5px;">
+                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_annex_ObSent" class="font-weight-bold">Annexure</label>
                         <select id="viewMemo_annex_ObSent" class="form-select form-control">
                             <option selected="selected" value="0" id="0">--Select Annexure--</option>
@@ -684,11 +684,11 @@
 
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid black;padding:5px;">
+                    <div class="form-group" style="border:1px solid black;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
                         <input id="viewMemo_risk_display" class="form-control" readonly />
                     </div>
-                    <div class="form-group" style="border:1px solid pink;padding:5px;">
+                    <div class="form-group" style="border:1px solid pink;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_process_ObSent" class="font-weight-bold">Process</label>
                         <select id="viewMemo_process_ObSent" onchange="getSubCheckListOfProcess();" class="form-select form-control">
                             <option selected="selected" value="0" id="0">--Select Process--</option>
@@ -705,26 +705,26 @@
 
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid yellow;padding:5px;">
+                    <div class="form-group" style="border:1px solid yellow;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_subprocess_ObSent" class="font-weight-bold">Sub Process</label>
                         <select id="viewMemo_subprocess_ObSent" onchange="getCheckListDetailOfSubProcess();" class="form-select form-control">
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid green;padding:5px;">
+                    <div class="form-group" style="border:1px solid green;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_checklist_ObSent" class="font-weight-bold">Checklist Details</label>
                         <select id="viewMemo_checklist_ObSent" class="form-select form-control">
                         </select>
                     </div>
 
-                    <div class="form-group" style="border:1px solid red;padding:5px;">
+                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_heading_ObSent" class="font-weight-bold">Gist of Para</label>
                         <input id="viewMemo_heading_ObSent" type="text" class="form-control" />
                     </div>
-                    <div class="form-group" style="border:1px solid green;padding:5px;">
+                    <div class="form-group" style="border:1px solid green;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_memo_ObSent" class="font-weight-bold">Para Text</label>
                         <input id="viewMemo_memo_ObSent" type="text" class="form-control" />
                     </div>
-                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;">
+                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;margin-bottom:10px;">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <div id="searchSection" style="display:none;"></div>

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -602,7 +602,7 @@
             </div>
             <div class="modal-body">
                 <form>
-                    <div class="form-group" style="border:1px solid red;padding:5px;">
+                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_annex" class="font-weight-bold">Annexure</label>
                         <select id="viewMemo_annex" disabled="disabled" class="form-select form-control">
                             <option selected="selected" value="0" id="0">--Select Annexure--</option>
@@ -620,7 +620,7 @@
 
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid black;padding:5px;">
+                    <div class="form-group" style="border:1px solid black;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_risk">Risk</label>
                         <select id="viewMemo_risk" disabled="disabled" class="form-select form-control" aria-label="Default select example">
                             <option value="0" id="0" selected>--Select Risk Category--</option>
@@ -636,23 +636,23 @@
                             }
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid pink;padding:5px;">
+                    <div class="form-group" style="border:1px solid pink;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_process" class="font-weight-bold">Process</label>
                         <div id="viewMemo_process" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div class="form-group" style="border:1px solid yellow;padding:5px;">
+                    <div class="form-group" style="border:1px solid yellow;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_subprocess" class="font-weight-bold">Sub Process</label>
                         <div id="viewMemo_subprocess" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div class="form-group" style="border:1px solid green;padding:5px;">
+                    <div class="form-group" style="border:1px solid green;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_violation" class="font-weight-bold">Checklist Details</label>
                         <div id="viewMemo_violation" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div class="form-group" style="border:1px solid red;padding:5px;">
+                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_memo" class="font-weight-bold">Memo</label>
                         <div id="viewMemo_memo" disabled="disabled" style="height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;">
+                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;margin-bottom:10px;">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <button class="btn btn-success mb-3" id="saveBtn">Save</button>
@@ -739,7 +739,7 @@
             </div>
             <div class="modal-body">
                 <form>
-                    <div class="form-group" style="border:1px solid red;padding:5px;">
+                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
                         <label>Annexure</label>
                         <div class="row col-md-12 w-100 m-0 p-0">
                             <select id="updateMemo_annex" class="form-select form-control">
@@ -761,12 +761,12 @@
 
                     </div>
 
-                    <div class="form-group" style="border:1px solid black;padding:5px;">
+                    <div class="form-group" style="border:1px solid black;padding:5px;margin-bottom:10px;">
                         <label for="updateMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
                         <input id="updateMemo_risk_display" class="form-control" readonly />
                     </div>
 
-                    <div class="form-group" style="border:1px solid pink;padding:5px;">
+                    <div class="form-group" style="border:1px solid pink;padding:5px;margin-bottom:10px;">
                         <label for="updateMemo_process" class="font-weight-bold">Process</label>
                         <select id="updateMemo_process" onchange="getSubProcessList();" class="form-select form-control" aria-label="Default select example">
                             <option value="0" id="0" selected="selected">--Select Voilation Category--</option>
@@ -781,28 +781,28 @@
                             }
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid yellow;padding:5px;">
+                    <div class="form-group" style="border:1px solid yellow;padding:5px;margin-bottom:10px;">
                         <label for="updateMemo_subprocess" class="font-weight-bold">Sub Process</label>
                         <select id="updateMemo_subprocess" onchange="getSubProcessViolationList();" class="form-select form-control" aria-label="Default select example">
                         </select>
 
                     </div>
-                    <div class="form-group" style="border:1px solid green;padding:5px;">
+                    <div class="form-group" style="border:1px solid green;padding:5px;margin-bottom:10px;">
                         <label for="updateMemo_violation" class="font-weight-bold">Checklist Details</label>
                         <select id="updateMemo_violation" class="form-select form-control" aria-label="Default select example">
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid red;padding:5px;">
+                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
                         <label for="updateMemo_heading" class="font-weight-bold">Title / Heading</label>
                         <input id="updateMemo_heading" class="form-control" />
                     </div>
-                    <div class="form-group" style="border:1px solid green;padding:5px;">
+                    <div class="form-group" style="border:1px solid green;padding:5px;margin-bottom:10px;">
                         <label for="updateMemoContent" class="font-weight-bold">Memo</label>
                         <textarea id="updateMemoContent" rows="5" class="form-control">
 
                         </textarea>
                     </div>
-                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;">
+                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;margin-bottom:10px;">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <button class="btn btn-success mb-3" id="saveBtn">Save</button>

--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -507,7 +507,7 @@
             </div>
             <div class="modal-body">
                 <form>
-                    <div class="form-group" style="border:1px solid red;padding:5px;">
+                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_annex_ObSent" class="font-weight-bold">Annexure</label>
                         <select id="viewMemo_annex_ObSent" class="form-select form-control">
                             <option selected="selected" value="0" id="0">--Select Annexure--</option>
@@ -525,11 +525,11 @@
 
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid black;padding:5px;">
+                    <div class="form-group" style="border:1px solid black;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
                         <input id="viewMemo_risk_display" class="form-control" readonly />
                     </div>
-                    <div class="form-group" style="border:1px solid pink;padding:5px;">
+                    <div class="form-group" style="border:1px solid pink;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_process_ObSent" class="font-weight-bold">Process</label>
                         <select id="viewMemo_process_ObSent" onchange="getSubCheckListOfProcess();" class="form-select form-control">
                             <option selected="selected" value="0" id="0">--Select Process--</option>
@@ -547,32 +547,31 @@
 
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid yellow;padding:5px;">
+                    <div class="form-group" style="border:1px solid yellow;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_subprocess_ObSent" class="font-weight-bold">Sub Process</label>
                         <select id="viewMemo_subprocess_ObSent" onchange="getCheckListDetailOfSubProcess();" class="form-select form-control">
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid green;padding:5px;">
+                    <div class="form-group" style="border:1px solid green;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_checklist_ObSent" class="font-weight-bold">Checklist Details</label>
                         <select id="viewMemo_checklist_ObSent" class="form-select form-control">
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid blue;padding:5px;">
+                    <div class="form-group" style="border:1px solid blue;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_paraNo_ObSent" class="font-weight-bold">Para No</label>
                         <input id="viewMemo_paraNo_ObSent" type="text" class="form-control" />
                     </div>
 
 
-                    </div>
-                    <div class="form-group" style="border:1px solid red;padding:5px;">
+                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_heading_ObSent" class="font-weight-bold">Gist of Para</label>
                         <input id="viewMemo_heading_ObSent" type="text" class="form-control" />
                     </div>
-                    <div class="form-group" style="border:1px solid green;padding:5px;">
+                    <div class="form-group" style="border:1px solid green;padding:5px;margin-bottom:10px;">
                         <label for="viewMemo_memo_ObSent" class="font-weight-bold">Para Text</label>
                         <input id="viewMemo_memo_ObSent" type="text" class="form-control" />
                     </div>
-                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;">
+                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;margin-bottom:10px;">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <button class="btn btn-success mb-3" id="saveBtn">Save</button>


### PR DESCRIPTION
## Summary
- add margin-bottom for clean spacing in update & details modals
- remove stray closing tag in pre-concluding audit view
- tweak draft audit report view styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f22cdc208832e97c319902f41f7dc