### PR TITLE
Improve reference section UI

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -724,7 +724,7 @@
                         <label for="viewMemo_memo_ObSent" class="font-weight-bold">Para Text</label>
                         <input id="viewMemo_memo_ObSent" type="text" class="form-control" />
                     </div>
-                    <div id="referenceSection" class="mt-3 p-3 border border-danger" style="margin-bottom:10px;">
+                    <div id="referenceSection" class="mt-3 p-3 border border-danger mb-3">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <div id="searchSection" style="display:none;"></div>

--- a/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
+++ b/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
@@ -388,7 +388,7 @@
                         <label for="viewMemo_memo">Memo</label>
                         <div class="col-md-12" style="max-height:500px; overflow-y:auto;" id="viewMemo_panel"></div>
                     </div>
-                    <div id="referenceSection" class="mt-3">
+                    <div id="referenceSection" class="mt-3 p-3 border border-danger">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
                         <div id="searchSection" style="display:none;"></div>

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -236,7 +236,7 @@
                 }else {
                     $('#complianceCycleEvidences').append("<i>No evidence is attached </i>");
                 }
-                initReferenceSection(obs_id, false);
+                initReferenceSection(obs_id, true);
             },
             dataType: "json",
         });
@@ -602,7 +602,7 @@
             </div>
             <div class="modal-body">
                 <form>
-                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
+                    <div class="form-group mb-3">
                         <label for="viewMemo_annex" class="font-weight-bold">Annexure</label>
                         <select id="viewMemo_annex" disabled="disabled" class="form-select form-control">
                             <option selected="selected" value="0" id="0">--Select Annexure--</option>
@@ -620,7 +620,7 @@
 
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid black;padding:5px;margin-bottom:10px;">
+                    <div class="form-group mb-3">
                         <label for="viewMemo_risk">Risk</label>
                         <select id="viewMemo_risk" disabled="disabled" class="form-select form-control" aria-label="Default select example">
                             <option value="0" id="0" selected>--Select Risk Category--</option>
@@ -636,26 +636,26 @@
                             }
                         </select>
                     </div>
-                    <div class="form-group" style="border:1px solid pink;padding:5px;margin-bottom:10px;">
+                    <div class="form-group mb-3">
                         <label for="viewMemo_process" class="font-weight-bold">Process</label>
                         <div id="viewMemo_process" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div class="form-group" style="border:1px solid yellow;padding:5px;margin-bottom:10px;">
+                    <div class="form-group mb-3">
                         <label for="viewMemo_subprocess" class="font-weight-bold">Sub Process</label>
                         <div id="viewMemo_subprocess" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div class="form-group" style="border:1px solid green;padding:5px;margin-bottom:10px;">
+                    <div class="form-group mb-3">
                         <label for="viewMemo_violation" class="font-weight-bold">Checklist Details</label>
                         <div id="viewMemo_violation" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div class="form-group" style="border:1px solid red;padding:5px;margin-bottom:10px;">
+                    <div class="form-group mb-3">
                         <label for="viewMemo_memo" class="font-weight-bold">Memo</label>
                         <div id="viewMemo_memo" disabled="disabled" style="height: auto; overflow-y: auto;" class="form-control"></div>
                     </div>
-                    <div id="referenceSection" class="mt-3 border p-3" style="border:1px solid red;margin-bottom:10px;">
+                    <div id="referenceSection" class="mt-3 p-3 border border-danger mb-3">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
-                        <button class="btn btn-success mb-3" id="saveBtn">Save</button>
+                        <button type="button" class="btn btn-success mb-3" id="saveBtn">Save</button>
                         <div id="searchSection">
                             <select id="refType" class="form-select mb-2">
                                 <option value="0" selected>Please select reference</option>
@@ -665,12 +665,12 @@
                             </select>
                             <div id="searchInputs" style="display:none;">
                                 <input id="keyword" class="form-control mb-2" placeholder="keyword" />
-                                <button class="btn btn-primary" id="searchBtn">Search</button>
+                                <button type="button" class="btn btn-primary" id="searchBtn">Search</button>
                             </div>
                             <div id="manualInputs" style="display:none;">
                                 <input id="manualName" class="form-control mb-2" placeholder="Manual/Policy Name" />
                                 <input id="chapterSection" class="form-control mb-2" placeholder="Chapter No + Section" />
-                                <button class="btn btn-primary" id="addManualBtn">Add</button>
+                                <button type="button" class="btn btn-primary" id="addManualBtn">Add</button>
                             </div>
                         </div>
                         <table class="table" id="resultTbl" style="display:none;">
@@ -802,10 +802,10 @@
 
                         </textarea>
                     </div>
-                    <div id="referenceSection" class="mt-3 p-3 border border-danger" style="margin-bottom:10px;">
+                    <div id="referenceSection" class="mt-3 p-3 border border-danger mb-3">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
-                        <button class="btn btn-success mb-3" id="saveBtn">Save</button>
+                        <button type="button" class="btn btn-success mb-3" id="saveBtn">Save</button>
                         <div id="searchSection">
                             <select id="refType" class="form-select mb-2">
                                 <option value="0" selected>Please select reference</option>
@@ -815,12 +815,12 @@
                             </select>
                             <div id="searchInputs" style="display:none;">
                                 <input id="keyword" class="form-control mb-2" placeholder="keyword" />
-                                <button class="btn btn-primary" id="searchBtn">Search</button>
+                                <button type="button" class="btn btn-primary" id="searchBtn">Search</button>
                             </div>
                             <div id="manualInputs" style="display:none;">
                                 <input id="manualName" class="form-control mb-2" placeholder="Manual/Policy Name" />
                                 <input id="chapterSection" class="form-control mb-2" placeholder="Chapter No + Section" />
-                                <button class="btn btn-primary" id="addManualBtn">Add</button>
+                                <button type="button" class="btn btn-primary" id="addManualBtn">Add</button>
                             </div>
                         </div>
                         <table class="table" id="resultTbl" style="display:none;">

--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -574,7 +574,7 @@
                     <div id="referenceSection" class="mt-3 p-3 border border-danger" style="margin-bottom:10px;">
                         <h6>References</h6>
                         <ul id="refList" class="list-group mb-3"></ul>
-                        <button class="btn btn-success mb-3" id="saveBtn">Save</button>
+                        <button type="button" class="btn btn-success mb-3" id="saveBtn">Save</button>
                         <div id="searchSection">
                             <select id="refType" class="form-select mb-2">
                                 <option value="0" selected>Please select reference</option>
@@ -584,12 +584,12 @@
                             </select>
                             <div id="searchInputs" style="display:none;">
                                 <input id="keyword" class="form-control mb-2" placeholder="keyword" />
-                                <button class="btn btn-primary" id="searchBtn">Search</button>
+                                <button type="button" class="btn btn-primary" id="searchBtn">Search</button>
                             </div>
                             <div id="manualInputs" style="display:none;">
                                 <input id="manualName" class="form-control mb-2" placeholder="Manual/Policy Name" />
                                 <input id="chapterSection" class="form-control mb-2" placeholder="Chapter No + Section" />
-                                <button class="btn btn-primary" id="addManualBtn">Add</button>
+                                <button type="button" class="btn btn-primary" id="addManualBtn">Add</button>
                             </div>
                         </div>
                         <table class="table" id="resultTbl" style="display:none;">


### PR DESCRIPTION
## Summary
- keep Observation references read-only for viewer
- fix button types to prevent page reloads
- remove debug borders and style reference boxes consistently

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f31e974c8832e906a41da1f2cbe5b