### PR TITLE
Fix complaint id retrieval

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3191,8 +3191,8 @@ namespace AIS.Controllers
         [HttpPost]
         public IActionResult AddAssessment([FromBody] AIS.Models.IID.InitialAssessmentModel model)
             {
-            dBConnection.AddAssessment(model);
-            return Ok();
+            var id = dBConnection.AddAssessment(model);
+            return Ok(new { AssessmentId = id });
             }
 
         [HttpPost]

--- a/AIS/AIS/DBConnection.IID.cs
+++ b/AIS/AIS/DBConnection.IID.cs
@@ -139,7 +139,8 @@ namespace AIS.Controllers
                 cmd.CommandText = "PKG_INQ.ADD_ASSESSMENT";
                 cmd.CommandType = CommandType.StoredProcedure;
                 cmd.Parameters.Add("p_complaint_id", OracleDbType.Int32).Value = model.ComplaintId;
-                cmd.Parameters.Add("p_received_by", OracleDbType.Int32).Value = model.ReceivedBy;
+                var receivedBy = model.ReceivedBy != 0 ? model.ReceivedBy : loggedInUser.PPNumber;
+                cmd.Parameters.Add("p_received_by", OracleDbType.Int32).Value = receivedBy;
                 cmd.Parameters.Add("p_assessment", OracleDbType.Clob).Value = model.Assessment ?? string.Empty;
                 cmd.Parameters.Add("p_recommendation", OracleDbType.Varchar2).Value = model.Recommendation ?? string.Empty;
                 cmd.Parameters.Add("o_assessment_id", OracleDbType.Int32).Direction = ParameterDirection.Output;

--- a/AIS/AIS/Views/IID/InitialAssessment.cshtml
+++ b/AIS/AIS/Views/IID/InitialAssessment.cshtml
@@ -81,13 +81,13 @@
                 var body = $('#complaintsTable tbody');
                 body.empty();
                 $.each(d,function(i,v){
-                    var row = '<tr>'+
+                    var row = '<tr data-complaintid="'+v.complaintId+'">'+
                             '<td>'+ (v.complaintId || '') +'</td>'+
                         '<td>'+ (v.nature || '') +'</td>'+
                         '<td>'+ (v.submittedOn || '') +'</td>'+
                         '<td>'+
-                                    '<button type="button" class="btn btn-sm btn-info me-1 view-btn" data-id="'+v.complaintId+'">View</button>'+
-                                    '<button type="button" class="btn btn-sm btn-primary assess-btn" data-id="'+v.complaintId+'">Assess</button>'+
+                                    '<button type="button" class="btn btn-sm btn-info me-1 view-btn">View</button>'+
+                                    '<button type="button" class="btn btn-sm btn-primary assess-btn">Assess</button>'+
                         '</td>'+
                         '</tr>';
                     body.append(row);
@@ -97,12 +97,13 @@
         }
 
         $(document).on('click','.assess-btn',function(){
-            $('#modalcomplaintId').val($(this).data('id'));
+            var id = $(this).closest('tr').data('complaintid');
+            $('#modalComplaintId').val(id);
             $('#assessmentModal').modal('show');
         });
 
         $(document).on('click','.view-btn',function(){
-            var id = $(this).data('id');
+            var id = $(this).closest('tr').data('complaintid');
                     $.post(g_asiBaseURL + '/ApiCalls/GetComplaint',{ complaintId: id },function(d){
                 $('#complaintContents').text(d.contents || '');
                 var html = '';
@@ -125,7 +126,7 @@
 
         $('#saveAssessment').click(function(){
             var formData = {
-                    complaintId: $('#modalcomplaintid').val(),
+                    complaintId: $('#modalComplaintId').val(),
                 Assessment: $('#assessmentForm [name="Assessment"]').val(),
                 Recommendation: $('#assessmentForm [name="Recommendation"]').val(),
                 ReceivedBy: loggedInUserId


### PR DESCRIPTION
## Summary
- store complaint id on table rows and read from row when assessing or viewing
- return AssessmentId from API
- default assessment ReceivedBy to logged in user if none provided

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f735185cc832e84e79e15c72e792f