### PR TITLE
Fix public holiday list API

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3285,8 +3285,9 @@ namespace AIS.Controllers
             }
 
         [HttpPost]
-        public List<PublicHolidayModel> get_all_public_holidays(int year = 0)
+        public List<PublicHolidayModel> get_all_public_holidays([FromBody] HolidayYearModel input)
             {
+            int year = input?.year ?? 0;
             return dBConnection.GetAllPublicHolidays(year);
             }
         [HttpPost]

--- a/AIS/AIS/Models/HolidayYearModel.cs
+++ b/AIS/AIS/Models/HolidayYearModel.cs
@@ -1,0 +1,7 @@
+namespace AIS.Models
+    {
+    public class HolidayYearModel
+        {
+        public int year { get; set; }
+        }
+    }


### PR DESCRIPTION
## Summary
- allow ApiCalls.get_all_public_holidays to accept year from JSON body
- add HolidayYearModel to represent incoming POST data

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68807177f6f8832ea8c390da2337f25c