### PR TITLE
Add reusable responsibility section script

### DIFF
--- a/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
@@ -12,6 +12,7 @@
     var g_respUsersArr = [];
     var g_index = 0;
     var g_ele = null;
+    var respSection = null;
     var g_instructionMap = [];
     var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
     var g_selectedRiskId = 0;
@@ -29,9 +30,12 @@
         for (var i = 1970; i <= currentYear; i++) {
             $('#auditPara_Period').append('<option value="' + i + '">' + i + '</option>');
         }
-
-
-
+        respSection = initResponsibilitySection({
+            tableSelector: "#listofRespPersons",
+            changesTableSelector: "#c_listofRespPersons",
+            modalSelector: "#ResponsiblePPModel",
+            comId: g_com_id
+        });
 
     });
     function getrelation(parentEntityId = 0, userEntityId = 0) {
@@ -256,77 +260,18 @@ function updateObservationStatus() {
         g_np_id = v.neW_PARA_ID;
         g_op_id = v.olD_PARA_ID;
         g_ind = v.indicator;
-
-        $('#listofRespPersons tbody').empty();
-        $('#c_listofRespPersons tbody').empty();
-        $.ajax({
-            url: g_asiBaseURL + "/ApiCalls/get_responsible_person_list",
-            type: "POST",
-            data: {
-                'PARA_ID': g_np_id != "" ? g_np_id : g_op_id,
-                'INDICATOR': g_ind,
-                'COM_ID': g_com_id
-            },
-            cache: false,
-            success: function (data) {
-                var sr = 1;
-                var sr_c = 1;
-                $.each(data, function (i, v) {
-                    if (v.indicator == "O") {
-                        $('#listofRespPersons tbody').append('<tr id="tr_' + v.pP_NO + '"><td>' + sr + '</td><td>' + v.pP_NO + '</td><td>' + v.emP_NAME + '</td><td>' + v.loaN_CASE + '</td><td>' + v.lC_AMOUNT + '</td><td>' + v.accounT_NUMBER + '</td><td>' + v.acC_AMOUNT + '</td><td>' + v.remarks + '</td><td class="text-center"><a href="#" onclick="event.preventDefault();updateRespRow(this);">Update / delete</a></td></tr>');
-                        sr++
-                    }
-                    else {
-                        $('#c_listofRespPersons tbody').append('<tr id="tr_' + v.pP_NO + '"><td>' + sr_c + '</td><td>' + v.pP_NO + '</td><td>' + v.emP_NAME + '</td><td>' + v.loaN_CASE + '</td><td>' + v.lC_AMOUNT + '</td><td>' + v.accounT_NUMBER + '</td><td>' + v.acC_AMOUNT + '</td><td>' + v.remarks + '</td></tr>');
-                        sr_c++;
-                    }
-
-                });
-
-            },
-            dataType: "json",
-        });
-
+        respSection.updateContext({ newParaId: g_np_id, oldParaId: g_op_id, indicator: g_ind, comId: g_com_id });
     }
 
     function openResponsiblePPs() {
         $('#ResponsiblePPModel').modal('show');
         $('#matchedPPNoPanels').empty();
         g_ele = null;
-        $('#addResponsibleButton').removeClass("d-none");
-        $('#updateResponsibleButton').addClass("d-none");
-        $('#deleteResponsibleButton').addClass("d-none");
         $('#responsiblePPNoEntryField').val('');
         return false;
     }
     function getMatchedPP() {
-        $('#matchedPPNoPanels').empty();
-        g_respUser = [];
-        $.ajax({
-            url: g_asiBaseURL + "/ApiCalls/get_employee_name_from_pp",
-            type: "POST",
-            data: {
-                'PP_NO': $('#responsiblePPNoEntryField').val()
-            },
-            cache: false,
-            success: function (data) {
-                g_respUser.push(data);
-                if (data.ppNumber > 0) {
-                    $('#matchedPPNoPanels').append('<div class="row"><div class="row col-md-12 mt-2"><div class="col-sm-4"><label>Responsible</label></div><div class="col-sm-8"><span>' + data.name + ' (' + data.ppNumber + ') </span> </div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label> Loan Case </label></div><div class="col-md-8"><input id="resp_loan_case" class="form-control" type="number" /></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label> LC Amount </label></div><div class="col-md-8"><input id="resp_loan_amount" class="form-control" type="number" /></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label> Account Number </label></div><div class="col-md-8"><input id="resp_account_number" class="form-control" type="number" /></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label>ACC Amount </label></div><div class="col-md-8"><input id="resp_account_amount" class="form-control" type="number" /></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label>Remarks/Reason</label></div><div class="col-md-8"><textarea id="resp_remarks" class="form-control" rows="3"></textarea></div></div></div></div>');
-                    if (g_ele != null) {
-                        $('#resp_loan_case').val($(g_ele).parent().parent().children('td').eq(3).html());
-                        $('#resp_loan_amount').val($(g_ele).parent().parent().children('td').eq(4).html());
-                        $('#resp_account_number').val($(g_ele).parent().parent().children('td').eq(5).html());
-                        $('#resp_account_amount').val($(g_ele).parent().parent().children('td').eq(6).html());
-                        $('#resp_remarks').val("");
-
-                    }
-                }
-                else
-                    $('#matchedPPNoPanels').append('<div class="row"><span>No record found..</span></div>');
-            },
-            dataType: "json",
-        });
+        respSection.getMatchedPP();
     }
           function updateRiskDisplay() {
             var annexId = $('#auditPara_Annex').val();
@@ -351,48 +296,7 @@ function updateObservationStatus() {
             $('#viewMemo_risk_display').css('color', color);
         }
     function addResponsibilityToMainTable(action) {
-        if (g_respUser[0].ppNumber > 0) {
-            var lc = $('#resp_loan_case').val();
-            var acc = $('#resp_account_number').val();
-            if (lc == "" && acc == "") {
-                alert("Please enter Either Loan Case Or Account Number to Proceed"); return false;
-            }
-            var srNo = $('#listofRespPersons tbody tr').length;
-            srNo++;
-            //  $('#listofRespPersons tbody').append('<tr id="tr_' + g_respUser[0].ppNumber + '"><td>' + srNo + '</td><td>' + g_respUser[0].ppNumber + '</td><td>' + g_respUser[0].name + '</td><td>' + $('#resp_loan_case').val() + '</td><td>' + $('#resp_loan_amount').val() + '</td><td>' + $('#resp_account_number').val() + '</td><td>' + $('#resp_account_amount').val() + '</td><td>' + $('#resp_remarks').val() + '</td><td class="text-center"><a href="#" onclick="event.preventDefault();updateRespRow(this);">Update / Delete</a></td></tr>');
-            g_respUsersArr.push(g_respUser[0]);
-            var v = g_allObs[g_index];
-            g_np_id = v.neW_PARA_ID;
-            g_op_id = v.olD_PARA_ID;
-            g_ind = v.indicator;
-            $.ajax({
-                url: g_asiBaseURL + "/ApiCalls/add_responsible_to_observation",
-                type: "POST",
-                data: {
-                    'PP_NO': g_respUser[0].ppNumber,
-                    'LOAN_CASE': $('#resp_loan_case').val(),
-                    'LC_AMOUNT': $('#resp_loan_amount').val(),
-                    'ACCOUNT_NUMBER': $('#resp_account_number').val(),
-                    'ACC_AMOUNT': $('#resp_account_amount').val(),
-                    'EMP_NAME': g_respUser[0].name,
-                    'REMARKS': $('#resp_remarks').val(),
-                    'NEW_PARA_ID': g_np_id,
-                    'OLD_PARA_ID': g_op_id,
-                    'INDICATOR': g_ind,
-                    'COM_ID': g_com_id,
-                    'ACTION': action
-                },
-                cache: false,
-                success: function (data) {
-                    alert(data.Message);
-                    onAlertCallback(responsibleCallback);
-
-                },
-                dataType: "json",
-            });
-
-        }
-
+        respSection.saveResp(action);
     }
 
     function deleteRespRow(e) {
@@ -407,7 +311,7 @@ function updateObservationStatus() {
         $('#deleteResponsibleButton').removeClass("d-none");
         $('#matchedPPNoPanels').empty();
         $('#responsiblePPNoEntryField').val($(e).parent().parent().attr('id').split('tr_')[1]);
-        getMatchedPP();
+        respSection.getMatchedPP();
 
     }
 

--- a/AIS/AIS/Views/Shared/_Layout.cshtml
+++ b/AIS/AIS/Views/Shared/_Layout.cshtml
@@ -211,6 +211,7 @@
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script src="~/js/referenceSection.js" asp-append-version="true"></script>
     <script src="~/js/circular.js" asp-append-version="true"></script>
+    <script src="~/js/responsibilitySection.js" asp-append-version="true"></script>
     <script type="text/javascript" src="~/lib/rich-text-editor/jquery.richtext.js"></script>
     <script type="text/javascript" src="~/lib/word-export/FileSaver.js"></script>
     <script type="text/javascript" src="~/lib/word-export/jquery.wordexport.js"></script>

--- a/AIS/AIS/wwwroot/js/responsibilitySection.js
+++ b/AIS/AIS/wwwroot/js/responsibilitySection.js
@@ -1,0 +1,149 @@
+function initResponsibilitySection(config) {
+    var opts = $.extend({
+        tableSelector: '#listofRespPersons',
+        changesTableSelector: '#c_listofRespPersons',
+        modalSelector: '#ResponsiblePPModel',
+        comId: 0,
+        newParaId: 0,
+        oldParaId: 0,
+        indicator: '',
+        readOnly: false
+    }, config || {});
+
+    var table = $(opts.tableSelector);
+    var changesTable = $(opts.changesTableSelector);
+    var modal = $(opts.modalSelector);
+    var respUser = [];
+    var selectedRow = null;
+
+    function load() {
+        if (!table.length) return;
+        table.find('tbody').empty();
+        if (changesTable.length) changesTable.find('tbody').empty();
+        $.ajax({
+            url: g_asiBaseURL + '/ApiCalls/get_responsible_person_list',
+            type: 'POST',
+            data: {
+                'PARA_ID': opts.newParaId ? opts.newParaId : opts.oldParaId,
+                'INDICATOR': opts.indicator,
+                'COM_ID': opts.comId
+            },
+            dataType: 'json',
+            success: function (data) {
+                var sr = 1; var sr_c = 1;
+                $.each(data, function (i, v) {
+                    var row = '<tr id="tr_' + v.pP_NO + '"><td>' + sr + '</td><td>' + v.pP_NO + '</td><td>' + v.emP_NAME + '</td><td>' + v.loaN_CASE + '</td><td>' + v.lC_AMOUNT + '</td><td>' + v.accounT_NUMBER + '</td><td>' + v.acC_AMOUNT + '</td><td>' + v.remarks + '</td>';
+                    if (!opts.readOnly && v.indicator === 'O')
+                        row += '<td class="text-center"><a href="#" class="updateResp">Update / delete</a></td>';
+                    row += '</tr>';
+                    if (v.indicator === 'O') {
+                        table.find('tbody').append(row); sr++; }
+                    else if (changesTable.length) {
+                        changesTable.find('tbody').append('<tr id="tr_' + v.pP_NO + '"><td>' + sr_c + '</td><td>' + v.pP_NO + '</td><td>' + v.emP_NAME + '</td><td>' + v.loaN_CASE + '</td><td>' + v.lC_AMOUNT + '</td><td>' + v.accounT_NUMBER + '</td><td>' + v.acC_AMOUNT + '</td><td>' + v.remarks + '</td></tr>'); sr_c++; }
+                });
+            }
+        });
+    }
+
+    function getMatchedPP() {
+        $('#matchedPPNoPanels').empty();
+        respUser = [];
+        $.ajax({
+            url: g_asiBaseURL + '/ApiCalls/get_employee_name_from_pp',
+            type: 'POST',
+            data: { 'PP_NO': $('#responsiblePPNoEntryField').val() },
+            dataType: 'json',
+            success: function (data) {
+                respUser.push(data);
+                if (data.ppNumber > 0) {
+                    $('#matchedPPNoPanels').append('<div class="row"><div class="row col-md-12 mt-2"><div class="col-sm-4"><label>Responsible</label></div><div class="col-sm-8"><span>' + data.name + ' (' + data.ppNumber + ')</span></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label> Loan Case </label></div><div class="col-md-8"><input id="resp_loan_case" class="form-control" type="number" /></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label> LC Amount </label></div><div class="col-md-8"><input id="resp_loan_amount" class="form-control" type="number" /></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label> Account Number </label></div><div class="col-md-8"><input id="resp_account_number" class="form-control" type="number" /></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label>ACC Amount </label></div><div class="col-md-8"><input id="resp_account_amount" class="form-control" type="number" /></div></div><div class="row col-md-12 mt-2"><div class="col-md-4"><label>Remarks/Reason</label></div><div class="col-md-8"><textarea id="resp_remarks" class="form-control" rows="3"></textarea></div></div></div>');
+                    if (selectedRow) {
+                        $('#resp_loan_case').val($(selectedRow).parent().parent().children('td').eq(3).html());
+                        $('#resp_loan_amount').val($(selectedRow).parent().parent().children('td').eq(4).html());
+                        $('#resp_account_number').val($(selectedRow).parent().parent().children('td').eq(5).html());
+                        $('#resp_account_amount').val($(selectedRow).parent().parent().children('td').eq(6).html());
+                        $('#resp_remarks').val('');
+                    }
+                } else {
+                    $('#matchedPPNoPanels').append('<div class="row"><span>No record found..</span></div>');
+                }
+            }
+        });
+    }
+
+    function saveResp(action) {
+        if (!respUser.length || respUser[0].ppNumber <= 0) return;
+        var lc = $('#resp_loan_case').val();
+        var acc = $('#resp_account_number').val();
+        if (lc === '' && acc === '') {
+            alert('Please enter Either Loan Case Or Account Number to Proceed');
+            return;
+        }
+        $.ajax({
+            url: g_asiBaseURL + '/ApiCalls/add_responsible_to_observation',
+            type: 'POST',
+            data: {
+                'PP_NO': respUser[0].ppNumber,
+                'LOAN_CASE': $('#resp_loan_case').val(),
+                'LC_AMOUNT': $('#resp_loan_amount').val(),
+                'ACCOUNT_NUMBER': $('#resp_account_number').val(),
+                'ACC_AMOUNT': $('#resp_account_amount').val(),
+                'EMP_NAME': respUser[0].name,
+                'REMARKS': $('#resp_remarks').val(),
+                'NEW_PARA_ID': opts.newParaId,
+                'OLD_PARA_ID': opts.oldParaId,
+                'INDICATOR': opts.indicator,
+                'COM_ID': opts.comId,
+                'ACTION': action
+            },
+            dataType: 'json',
+            success: function (data) {
+                alert(data.Message);
+                modal.modal('hide');
+                load();
+            }
+        });
+    }
+
+    table.off('click', '.updateResp').on('click', '.updateResp', function (e) {
+        e.preventDefault();
+        selectedRow = this;
+        modal.modal('show');
+        $('#addResponsibleButton').addClass('d-none');
+        $('#updateResponsibleButton').removeClass('d-none');
+        $('#deleteResponsibleButton').removeClass('d-none');
+        $('#matchedPPNoPanels').empty();
+        $('#responsiblePPNoEntryField').val($(this).parent().parent().attr('id').split('tr_')[1]);
+        getMatchedPP();
+    });
+
+    if (!opts.readOnly) {
+        $('#addResponsibleButton').off('click').on('click', function () { saveResp('A'); });
+        $('#updateResponsibleButton').off('click').on('click', function () { saveResp('U'); });
+        $('#deleteResponsibleButton').off('click').on('click', function () { saveResp('D'); });
+        $('#responsiblePPNoEntryField').off('keypress').on('keypress', function (e) { if (e.which === 13) { e.preventDefault(); getMatchedPP(); } });
+        modal.on('show.bs.modal', function () {
+            $('#matchedPPNoPanels').empty();
+            selectedRow = null;
+            respUser = [];
+            $('#responsiblePPNoEntryField').val('');
+            $('#addResponsibleButton').removeClass('d-none');
+            $('#updateResponsibleButton').addClass('d-none');
+            $('#deleteResponsibleButton').addClass('d-none');
+        });
+    }
+
+    function updateContext(c) {
+        opts = $.extend(opts, c || {});
+        load();
+    }
+
+    load();
+
+    return {
+        reload: load,
+        updateContext: updateContext,
+        getMatchedPP: getMatchedPP,
+        saveResp: saveResp
+    };
+}


### PR DESCRIPTION
## Summary
- create `responsibilitySection.js` to handle responsibilities UI
- load new script from `_Layout`
- initialize and use the new script in `manage_audit_paras`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc84608c4832ea47193159094f0fa