### PR TITLE
Add responsibilitySection to report views

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -24,6 +24,7 @@
     var g_subProcId=0;
     var g_procDetailId=0;
     var g_selectedRiskId = 0;
+    var respSection = null;
     var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
     $(document).ready(function () {
         $('#entitySelectField').select2();
@@ -38,6 +39,10 @@
             urls: false
         });
         $('#viewMemo_annex_ObSent').on('change', updateRiskDisplay);
+        respSection = initResponsibilitySection({
+            tableSelector: '#viewMemo_respPP_ObSent',
+            readOnly: true
+        });
 
          document.getElementById('viewMemo_amount_ObSent').addEventListener('input', function (e) {
         this.value = this.value.replace(/\D|^0(?=\d)/g, ''); // Removes decimals and leading zeros
@@ -245,16 +250,13 @@
          g_subProcId=data.subchecklisT_ID;
          g_procDetailId=data.checklistdetaiL_ID;
          getSubCheckListOfProcess();
-         $('#viewMemo_respPP_ObSent tbody').empty();
-           if(data.responsiblE_PPNO != null){
-                    if (data.responsiblE_PPNO.length > 0) {
-                    $.each(data.responsiblE_PPNO, function (j, pp) {
-                        var srNo = $('#viewMemo_respPP_ObSent tbody tr').length;
-                        srNo++;
-                        $('#viewMemo_respPP_ObSent tbody').append('<tr id="tr_' + pp.pP_NO + '"><td>' + srNo + '</td><td>' + pp.pP_NO + '</td><td>' + pp.emP_NAME + '</td><td>' + pp.loaN_CASE + '</td><td>' + pp.lC_AMOUNT + '</td><td>' + pp.accounT_NUMBER + '</td><td>' + pp.acC_AMOUNT + '</td></tr>');
-                    });
-                }
-               }
+        respSection.updateContext({
+            newParaId: data.neW_PARA_ID,
+            oldParaId: data.olD_PARA_ID,
+            indicator: data.indicator,
+            comId: data.coM_ID,
+            readOnly: true
+        });
                initReferenceSection(g_obsId, true, '#viewMemoDetailsModel #referenceSection');
                },
             dataType: "json",

--- a/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
+++ b/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
@@ -19,12 +19,18 @@
     var g_newStatusId = 0;
     var g_riskId = 0;
     var g_obsList = [];
+    var respSection = null;
     $(document).ready(function () {
         $('#entitySelectField').select2();
         var entName = $('#manageObsPanel tbody .entity_name_field:first').text();
         $('#entityNameField').val(entName);
         var periodName = $('#manageObsPanel tbody .period_name_field:first').text();
         $('#auditPeriodNameField').val(periodName);
+
+        respSection = initResponsibilitySection({
+            tableSelector: '#viewMemo_respPP_ObSent',
+            readOnly: true
+        });
 
 
     });
@@ -43,6 +49,7 @@
             cache: false,
             success: function (data) {
                 $('#viewMemo_panel').html(data[0].obS_TEXT);
+                respSection.updateContext({ newParaId: id });
                 initReferenceSection(id, true, '#viewMemoModel #referenceSection');
             },
             dataType: "json",
@@ -387,6 +394,25 @@
                     <div class="form-group">
                         <label for="viewMemo_memo">Memo</label>
                         <div class="col-md-12" style="max-height:500px; overflow-y:auto;" id="viewMemo_panel"></div>
+                    </div>
+                    <div class="form-group">
+                        <label for="viewMemo_respPP_ObSent" class="font-weight-bold">Responsible Personals</label>
+                        <div class="col-md-12 pl-0 pr-0">
+                            <table id="viewMemo_respPP_ObSent" class="table table-hover table-bordered table-hover mt-3 table-striped">
+                                <thead style="background-color: #19875478 !important; ">
+                                    <tr>
+                                        <th class="col-md- auto font-weight-bold">Sr.No</th>
+                                        <th class="col-md- auto font-weight-bold">P.P. No</th>
+                                        <th class="col-md- auto font-weight-bold">Name</th>
+                                        <th class="col-md- auto font-weight-bold">Loan Case</th>
+                                        <th class="col-md- auto font-weight-bold">LC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Account No.</th>
+                                        <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
                     </div>
                     <div id="referenceSection" class="mt-3 p-3 border border-danger">
                         <h6>References</h6>

--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -10,6 +10,7 @@
     var g_subProcId = 0;
     var g_procDetailId = 0;
     var g_selectedRiskId = 0;
+    var respSection = null;
     var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
 
     $(document).ready(function () {
@@ -21,6 +22,10 @@
              urls: false
          });
         $('#viewMemo_annex_ObSent').on('change', updateRiskDisplay);
+        respSection = initResponsibilitySection({
+            tableSelector: '#viewMemo_respPP_ObSent',
+            readOnly: true
+        });
 
 
 
@@ -135,16 +140,13 @@
            g_subProcId=data.subchecklisT_ID;
            g_procDetailId=data.checklistdetaiL_ID;
            getSubCheckListOfProcess();
-            $('#viewMemo_respPP_ObSent tbody').empty();
-             if(data.responsiblE_PPNO != null){
-                      if (data.responsiblE_PPNO.length > 0) {
-                      $.each(data.responsiblE_PPNO, function (j, pp) {
-                          var srNo = $('#viewMemo_respPP_ObSent tbody tr').length;
-                          srNo++;
-                          $('#viewMemo_respPP_ObSent tbody').append('<tr id="tr_' + pp.pP_NO + '"><td>' + srNo + '</td><td>' + pp.pP_NO + '</td><td>' + pp.emP_NAME + '</td><td>' + pp.loaN_CASE + '</td><td>' + pp.lC_AMOUNT + '</td><td>' + pp.accounT_NUMBER + '</td><td>' + pp.acC_AMOUNT + '</td></tr>');
-                      });
-                  }
-                 }
+        respSection.updateContext({
+            newParaId: data.neW_PARA_ID,
+            oldParaId: data.olD_PARA_ID,
+            indicator: data.indicator,
+            comId: data.coM_ID,
+            readOnly: true
+        });
                  initReferenceSection(g_obsId, false, '#viewMemoDetailsModel #referenceSection');
                  },
               dataType: "json",


### PR DESCRIPTION
## Summary
- initialize `respSection` in relevant draft report views
- load responsible persons via `initResponsibilitySection`
- display responsibility table in `manage_draft_report_paras_branch`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688073c6dd48832eae98a58f6aceb1ef