### PR TITLE
Add responsibility section modals

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -41,7 +41,7 @@
         $('#viewMemo_annex_ObSent').on('change', updateRiskDisplay);
         respSection = initResponsibilitySection({
             tableSelector: '#viewMemo_respPP_ObSent',
-            readOnly: true
+            modalSelector: '#ResponsiblePPModel'
         });
 
          document.getElementById('viewMemo_amount_ObSent').addEventListener('input', function (e) {
@@ -458,6 +458,9 @@
         const blob = new Blob(byteArrays, { type: contentType });
         return blob;
     }
+    function openResponsiblePPs() {
+        $('#ResponsiblePPModel').modal('show');
+    }
     function updateObservationDetails(obsId){
 
         $.ajax({
@@ -765,6 +768,7 @@
                                         <th class="col-md- auto font-weight-bold">LC Amount</th>
                                         <th class="col-md- auto font-weight-bold">Account No.</th>
                                         <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                        <th class="col-md- auto text-center font-weight-bold"><center><button type="button" onclick="openResponsiblePPs();" class="rounded-circle btn btn-danger btn-sm"><i class="fa fa-plus text-white"></i></button></center></th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -801,6 +805,40 @@
     </div>
 </div>
 
+<div id="ResponsiblePPModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title">Responsible Person</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group">
+                        <label for="responsiblePPNoEntryField">P.P No.</label>
+                        <div class="row col-sm-12">
+                            <div class="col-sm-10">
+                                <input type="text" class="form-control" id="responsiblePPNoEntryField" />
+                            </div>
+                            <div class="col-sm-2 w-100">
+                                <button type="button" onclick="respSection.getMatchedPP();" class="btn btn-danger">Find</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div id="matchedPPNoPanels" style="padding:20px;"></div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button id="addResponsibleButton" type="button" class="btn btn-danger">Add Responsibility</button>
+                <button id="updateResponsibleButton" type="button" class="btn btn-success d-none">Update Responsibility</button>
+                <button id="deleteResponsibleButton" type="button" class="btn btn-danger d-none">Delete Responsibility</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
 
 <div id="DSAModel" class="modal" tabindex="-1" role="dialog">
     <div class="modal-dialog modal-xl" style="width:95% !important;" role="document">

--- a/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
+++ b/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
@@ -29,7 +29,7 @@
 
         respSection = initResponsibilitySection({
             tableSelector: '#viewMemo_respPP_ObSent',
-            readOnly: true
+            modalSelector: '#ResponsiblePPModel'
         });
 
 
@@ -291,6 +291,9 @@
         const blob = new Blob(byteArrays, { type: contentType });
         return blob;
     }
+    function openResponsiblePPs() {
+        $('#ResponsiblePPModel').modal('show');
+    }
 
 </script>
 
@@ -408,6 +411,7 @@
                                         <th class="col-md- auto font-weight-bold">LC Amount</th>
                                         <th class="col-md- auto font-weight-bold">Account No.</th>
                                         <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                        <th class="col-md- auto text-center font-weight-bold"><center><button type="button" onclick="openResponsiblePPs();" class="rounded-circle btn btn-danger btn-sm"><i class="fa fa-plus text-white"></i></button></center></th>
                                     </tr>
                                 </thead>
                                 <tbody></tbody>
@@ -472,3 +476,37 @@
 </div>
 
 
+<div id="ResponsiblePPModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title">Responsible Person</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group">
+                        <label for="responsiblePPNoEntryField">P.P No.</label>
+                        <div class="row col-sm-12">
+                            <div class="col-sm-10">
+                                <input type="text" class="form-control" id="responsiblePPNoEntryField" />
+                            </div>
+                            <div class="col-sm-2 w-100">
+                                <button type="button" onclick="respSection.getMatchedPP();" class="btn btn-danger">Find</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div id="matchedPPNoPanels" style="padding:20px;"></div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button id="addResponsibleButton" type="button" class="btn btn-danger">Add Responsibility</button>
+                <button id="updateResponsibleButton" type="button" class="btn btn-success d-none">Update Responsibility</button>
+                <button id="deleteResponsibleButton" type="button" class="btn btn-danger d-none">Delete Responsibility</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -25,6 +25,8 @@
     var g_obsList = [];
     var g_selectedRiskId = 0;
     var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
+    var respSectionView = null;
+    var respSectionUpdate = null;
     $(document).ready(function () {
         $('#entitySelectField').select2();
         var entName = $('#manageObsPanel tbody .entity_name_field:first').text();
@@ -39,6 +41,15 @@
             urls: false
         });
         $('#updateMemo_annex').on('change', updateRiskDisplay);
+        respSectionView = initResponsibilitySection({
+            tableSelector: '#listofRespPersons',
+            readOnly: true
+        });
+        respSectionUpdate = initResponsibilitySection({
+            tableSelector: '#update_listofRespPersons',
+            changesTableSelector: '#c_update_listofRespPersons',
+            modalSelector: '#ResponsiblePPModel'
+        });
     });
     function reloadLocation() {
         getEntityObservation();
@@ -237,6 +248,7 @@
                     $('#complianceCycleEvidences').append("<i>No evidence is attached </i>");
                 }
                 initReferenceSection(obs_id, true, '#viewMemoModel #referenceSection');
+                respSectionView.updateContext({ newParaId: obs_id });
             },
             dataType: "json",
         });
@@ -264,6 +276,7 @@
                 $('#updateMemo_violation').empty();
                 $('#updateMemo_violation').append('<option value="0">' + data[0].checklist_Details + '</option>');
                 initReferenceSection(obs_id, false, '#updateMemoModel #referenceSection');
+                respSectionUpdate.updateContext({ newParaId: obs_id });
             },
             dataType: "json",
         });
@@ -442,6 +455,9 @@
             dataType: "json",
         });
 
+    }
+    function openResponsiblePPs() {
+        $('#ResponsiblePPModel').modal('show');
     }
     function downloadFile(id) {
         $.ajax({
@@ -688,6 +704,47 @@
                         </table>
                     </div>
                     <div class="form-group">
+                        <label for="update_listofRespPersons" class="font-weight-bold">Responsible Personals</label>
+                        <div class="row col-sm-12">
+                            <table id="update_listofRespPersons" class="table table-hover table-bordered table-hover mt-3 table-striped">
+                                <thead style="background-color: #19875478 !important; ">
+                                    <tr>
+                                        <th class="col-md- auto font-weight-bold">Sr.No</th>
+                                        <th class="col-md- auto font-weight-bold">P.P. No</th>
+                                        <th class="col-md- auto font-weight-bold">Name</th>
+                                        <th class="col-md- auto font-weight-bold">Loan Case</th>
+                                        <th class="col-md- auto font-weight-bold">LC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Account No.</th>
+                                        <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Remarks</th>
+                                        <th class="col-md- auto text-center font-weight-bold"><center><button type="button" onclick="openResponsiblePPs();" class="rounded-circle btn btn-danger btn-sm"><i class="fa fa-plus text-white"></i></button></center></th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <center><h6>Changes in Responsibilities</h6></center>
+                        <div class="row col-sm-12">
+                            <table id="c_update_listofRespPersons" class="table table-hover table-bordered table-hover mt-3 table-striped">
+                                <thead style="background-color: #19875478 !important; ">
+                                    <tr>
+                                        <th class="col-md- auto font-weight-bold">Sr.No</th>
+                                        <th class="col-md- auto font-weight-bold">P.P. No</th>
+                                        <th class="col-md- auto font-weight-bold">Name</th>
+                                        <th class="col-md- auto font-weight-bold">Loan Case</th>
+                                        <th class="col-md- auto font-weight-bold">LC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Account No.</th>
+                                        <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Remarks</th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="form-group">
                         <label for="viewMemo_respPP" class="font-weight-bold">Responsible Personals</label>
                         <div class="col-md-12 pl-0 pr-0">
                             <table id="listofRespPersons" class="table table-hover table-bordered table-hover mt-3 table-striped">
@@ -844,6 +901,41 @@
 
                 <button id="updateMemoContent_submit" onclick="finalUpdateMemoContent(g_obsId);" type="button" data-bs-dismiss="modal" class="btn btn-danger">Update Memo Text</button>
 
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="ResponsiblePPModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title">Responsible Person</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group">
+                        <label for="responsiblePPNoEntryField">P.P No.</label>
+                        <div class="row col-sm-12">
+                            <div class="col-sm-10">
+                                <input type="text" class="form-control" id="responsiblePPNoEntryField" />
+                            </div>
+                            <div class="col-sm-2 w-100">
+                                <button type="button" onclick="respSectionUpdate.getMatchedPP();" class="btn btn-danger">Find</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div id="matchedPPNoPanels" style="padding:20px;"></div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button id="addResponsibleButton" type="button" class="btn btn-danger">Add Responsibility</button>
+                <button id="updateResponsibleButton" type="button" class="btn btn-success d-none">Update Responsibility</button>
+                <button id="deleteResponsibleButton" type="button" class="btn btn-danger d-none">Delete Responsibility</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>

--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -24,7 +24,7 @@
         $('#viewMemo_annex_ObSent').on('change', updateRiskDisplay);
         respSection = initResponsibilitySection({
             tableSelector: '#viewMemo_respPP_ObSent',
-            readOnly: true
+            modalSelector: '#ResponsiblePPModel'
         });
 
 
@@ -330,9 +330,9 @@
               default: return 'application/octet-stream';
           }
       }
-      function base64ToBlob(base64, contentType) {
-          const byteCharacters = atob(base64);
-          const byteArrays = [];
+    function base64ToBlob(base64, contentType) {
+        const byteCharacters = atob(base64);
+        const byteArrays = [];
 
           for (let offset = 0; offset < byteCharacters.length; offset += 512) {
               const slice = byteCharacters.slice(offset, offset + 512);
@@ -346,9 +346,12 @@
               byteArrays.push(byteArray);
           }
 
-          const blob = new Blob(byteArrays, { type: contentType });
-          return blob;
-      }
+        const blob = new Blob(byteArrays, { type: contentType });
+        return blob;
+    }
+    function openResponsiblePPs() {
+        $('#ResponsiblePPModel').modal('show');
+    }
       function updateObservationDetails(obsId){
 
           $.ajax({
@@ -629,6 +632,7 @@
                                         <th class="col-md- auto font-weight-bold">LC Amount</th>
                                         <th class="col-md- auto font-weight-bold">Account No.</th>
                                         <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                        <th class="col-md- auto text-center font-weight-bold"><center><button type="button" onclick="openResponsiblePPs();" class="rounded-circle btn btn-danger btn-sm"><i class="fa fa-plus text-white"></i></button></center></th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -674,6 +678,40 @@
                 <button id="gist_recom_inc_pre_con" onclick="saveObservationGistandRecommendation(g_obsId);" type="button" class="btn btn-primary">Save Title & Recommendation</button>
                 <button id="update_audit_obs_button" onclick="updateObservationDetailsWithReference(g_obsId);" type="button" class="btn btn-danger">Update Para Details</button>
 
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="ResponsiblePPModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title">Responsible Person</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group">
+                        <label for="responsiblePPNoEntryField">P.P No.</label>
+                        <div class="row col-sm-12">
+                            <div class="col-sm-10">
+                                <input type="text" class="form-control" id="responsiblePPNoEntryField" />
+                            </div>
+                            <div class="col-sm-2 w-100">
+                                <button type="button" onclick="respSection.getMatchedPP();" class="btn btn-danger">Find</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div id="matchedPPNoPanels" style="padding:20px;"></div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button id="addResponsibleButton" type="button" class="btn btn-danger">Add Responsibility</button>
+                <button id="updateResponsibleButton" type="button" class="btn btn-success d-none">Update Responsibility</button>
+                <button id="deleteResponsibleButton" type="button" class="btn btn-danger d-none">Delete Responsibility</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- incorporate `responsibilitySection.js` in observation viewer and updater
- support editing of responsibles on draft and pre-concluding pages
- display editable responsibility tables in update memo modal

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688353af4ff0832ea60ca551285d4a6f