### PR TITLE
Fix responsibilities update alert

### DIFF
--- a/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
@@ -34,7 +34,8 @@
             tableSelector: "#listofRespPersons",
             changesTableSelector: "#c_listofRespPersons",
             modalSelector: "#ResponsiblePPModel",
-            comId: g_com_id
+            comId: g_com_id,
+            status: 8
         });
         auditParaSection = initFieldAuditParaSection({
             containerSelector: '#viewMemoModel',
@@ -265,7 +266,7 @@ function updateObservationStatus() {
         g_np_id = v.neW_PARA_ID;
         g_op_id = v.olD_PARA_ID;
         g_ind = v.indicator;
-        respSection.updateContext({ newParaId: g_np_id, oldParaId: g_op_id, indicator: g_ind, comId: g_com_id });
+        respSection.updateContext({ newParaId: g_np_id, oldParaId: g_op_id, indicator: g_ind, comId: g_com_id, status: 8 });
     }
 
     function openResponsiblePPs() {

--- a/AIS/AIS/wwwroot/js/responsibilitySection.js
+++ b/AIS/AIS/wwwroot/js/responsibilitySection.js
@@ -237,7 +237,8 @@ function initResponsibilitySection(config) {
             },
             dataType: 'json',
             success: function (data) {
-                alert(data.Message);
+                var msg = data.Message || data.message || 'Operation completed';
+                alert(msg);
                 modal.modal('hide');
                 load();
             }


### PR DESCRIPTION
## Summary
- show alert message correctly when updating responsibilities
- initialize responsibility section with status for audit paras

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884ed70b588832eb9d85cb9e3c4f536