### PR TITLE
Fix indicator sent when saving responsibles

### DIFF
--- a/AIS/AIS/wwwroot/js/responsibilitySection.js
+++ b/AIS/AIS/wwwroot/js/responsibilitySection.js
@@ -230,7 +230,8 @@ function initResponsibilitySection(config) {
                 'REMARKS': $('#resp_remarks').val(),
                 'NEW_PARA_ID': opts.newParaId,
                 'OLD_PARA_ID': opts.oldParaId,
-                'INDICATOR': opts.indicator,
+                // use action indicator for add/update/delete operations
+                'INDICATOR': action,
                 'COM_ID': opts.comId,
                 'ACTION': action,
                 'PARA_STATUS': opts.status


### PR DESCRIPTION
## Summary
- ensure correct indicator is sent for add/update/delete actions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f18c8a68832e87b6d96d7cad5f87