### PR TITLE
Enable searching for subchecklist dropdown

### DIFF
--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -27,6 +27,7 @@
         });
 
         $('#updatedAnnexlist').select2();
+        $('#riskActivitiesSelectBox').select2();
         $('#updatedAnnexlist').on('change', updateRiskDisplay);
         // initialize reference section using shared script
         initReferenceSection(0, false, '#referenceSection');
@@ -85,6 +86,12 @@
                     $('#riskActivitiesSelectBox').append("<option value=\"" + item.id + "\"> " + item.heading + "</option>");
                 });
 
+                if ($.fn.select2) {
+                    if ($('#riskActivitiesSelectBox').data('select2')) {
+                        $('#riskActivitiesSelectBox').select2('destroy');
+                    }
+                    $('#riskActivitiesSelectBox').select2();
+                }
             },
             dataType: "json",
         });


### PR DESCRIPTION
## Summary
- initialize Select2 for the risk activities dropdown
- re-initialize Select2 each time activities are loaded

## Testing
- `dotnet build AIS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885e01b72c0832eb1f7caa752dffabc