### PR TITLE
Enable responsibility modal CRUD with API integration

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -257,7 +257,7 @@
             oldParaId: data.olD_PARA_ID,
             indicator: data.indicator,
             comId: data.coM_ID,
-            readOnly: true
+            readOnly: false
         });
                initReferenceSection(g_obsId, true, '#viewMemoDetailsModel #referenceSection');
                },
@@ -462,6 +462,9 @@
     }
     function openResponsiblePPs() {
         $('#ResponsiblePPModel').modal('show');
+    }
+    function addResponsibilityToMainTable(action) {
+        respSection.saveResp(action);
     }
     function updateObservationDetails(obsId){
 
@@ -870,7 +873,9 @@
                 </form>
             </div>
             <div class="modal-footer">
-                <button onclick="addResponsibilityToMainTable();" type="button" data-bs-dismiss="modal" class="btn btn-danger">Add Responsibility</button>
+                <button id="addResponsibleButton" onclick="addResponsibilityToMainTable('A');" type="button" class="btn btn-danger">Add Responsibility</button>
+                <button id="updateResponsibleButton" onclick="addResponsibilityToMainTable('U');" type="button" class="btn btn-success d-none">Update Responsibility</button>
+                <button id="deleteResponsibleButton" onclick="addResponsibilityToMainTable('D');" type="button" class="btn btn-danger d-none">Delete Responsibility</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>

--- a/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
+++ b/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
@@ -296,6 +296,9 @@
     function openResponsiblePPs() {
         $('#ResponsiblePPModel').modal('show');
     }
+    function addResponsibilityToMainTable(action) {
+        respSection.saveResp(action);
+    }
 
 </script>
 
@@ -541,7 +544,9 @@
                 </form>
             </div>
             <div class="modal-footer">
-                <button onclick="addResponsibilityToMainTable();" type="button" data-bs-dismiss="modal" class="btn btn-danger">Add Responsibility</button>
+                <button id="addResponsibleButton" onclick="addResponsibilityToMainTable('A');" type="button" class="btn btn-danger">Add Responsibility</button>
+                <button id="updateResponsibleButton" onclick="addResponsibilityToMainTable('U');" type="button" class="btn btn-success d-none">Update Responsibility</button>
+                <button id="deleteResponsibleButton" onclick="addResponsibilityToMainTable('D');" type="button" class="btn btn-danger d-none">Delete Responsibility</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -464,6 +464,9 @@
     function openResponsiblePPs() {
         $('#ResponsiblePPModel').modal('show');
     }
+    function addResponsibilityToMainTable(action) {
+        respSectionUpdate.saveResp(action);
+    }
     function downloadFile(id) {
         $.ajax({
             url: g_asiBaseURL + "/ApiCalls/get_auditee_evidence_data",
@@ -956,7 +959,9 @@
                 </form>
             </div>
             <div class="modal-footer">
-                <button onclick="addResponsibilityToMainTable();" type="button" data-bs-dismiss="modal" class="btn btn-danger">Add Responsibility</button>
+                <button id="addResponsibleButton" onclick="addResponsibilityToMainTable('A');" type="button" class="btn btn-danger">Add Responsibility</button>
+                <button id="updateResponsibleButton" onclick="addResponsibilityToMainTable('U');" type="button" class="btn btn-success d-none">Update Responsibility</button>
+                <button id="deleteResponsibleButton" onclick="addResponsibilityToMainTable('D');" type="button" class="btn btn-danger d-none">Delete Responsibility</button>
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             </div>
         </div>

--- a/AIS/AIS/wwwroot/js/responsibilitySection.js
+++ b/AIS/AIS/wwwroot/js/responsibilitySection.js
@@ -242,6 +242,13 @@ function initResponsibilitySection(config) {
                 alert(msg);
                 modal.modal('hide');
                 load();
+            },
+            error: function (xhr) {
+                var msg = 'Error occurred';
+                if (xhr.responseJSON) {
+                    msg = xhr.responseJSON.Message || xhr.responseJSON.message || msg;
+                }
+                alert(msg);
             }
         });
     }
@@ -261,7 +268,11 @@ function initResponsibilitySection(config) {
     if (!opts.readOnly) {
         $('#addResponsibleButton').off('click').on('click', function () { saveResp('A'); });
         $('#updateResponsibleButton').off('click').on('click', function () { saveResp('U'); });
-        $('#deleteResponsibleButton').off('click').on('click', function () { saveResp('D'); });
+        $('#deleteResponsibleButton').off('click').on('click', function () {
+            if (confirm('Are you sure you want to delete this responsibility?')) {
+                saveResp('D');
+            }
+        });
         $('#responsiblePPNoEntryField').off('keypress').on('keypress', function (e) { if (e.which === 13) { e.preventDefault(); getMatchedPP(); } });
         modal.on('show.bs.modal', function () {
             $('#matchedPPNoPanels').empty();


### PR DESCRIPTION
## Summary
- enable add/update/delete actions in responsibility modals across branch views
- handle server errors and confirm deletions in responsibilitySection.js
- allow editing of responsibilities in draft audit report branch view

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cd7d76914832ebfabe6ec7f637c64