### PR TITLE
fix: refresh responsibility modal after changes

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -46,6 +46,12 @@
             directSaveMode: false
         });
 
+        $('#ResponsiblePPModel').on('hidden.bs.modal', function () {
+            if (respSection) {
+                respSection.reload();
+            }
+        });
+
          document.getElementById('viewMemo_amount_ObSent').addEventListener('input', function (e) {
         this.value = this.value.replace(/\D|^0(?=\d)/g, ''); // Removes decimals and leading zeros
     });

--- a/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
+++ b/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
@@ -34,6 +34,12 @@
             directSaveMode: false
         });
 
+        $('#ResponsiblePPModel').on('hidden.bs.modal', function () {
+            if (respSection) {
+                respSection.reload();
+            }
+        });
+
 
     });
     function reloadLocation() {

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -54,6 +54,14 @@
             status: 1,
             directSaveMode: false
         });
+        $('#ResponsiblePPModel').on('hidden.bs.modal', function () {
+            if (respSectionUpdate) {
+                respSectionUpdate.reload();
+            }
+            if (respSectionView) {
+                respSectionView.reload();
+            }
+        });
     });
     function reloadLocation() {
         getEntityObservation();

--- a/AIS/AIS/wwwroot/js/responsibilitySection.js
+++ b/AIS/AIS/wwwroot/js/responsibilitySection.js
@@ -241,9 +241,17 @@ function initResponsibilitySection(config) {
             dataType: 'json',
             success: function (data) {
                 var msg = data.Message || data.message || 'Operation completed';
+                if (typeof msg === 'string' && msg.toLowerCase().includes('already exists')) {
+                    msg = 'Responsibility Fixed';
+                }
                 alert(msg);
-                modal.modal('hide');
+                // ensure grids are refreshed with fresh data
+                table.find('tbody').empty();
+                if (changesTable.length) {
+                    changesTable.find('tbody').empty();
+                }
                 load();
+                // clear modal fields after save
                 $('#matchedPPNoPanels').empty();
                 $('#matchedPPNoPanelsBYPP').empty();
                 $('#responsiblePPNoEntryField').val('');
@@ -253,11 +261,15 @@ function initResponsibilitySection(config) {
                 $('#responsibleLoanAmountEntryField').val('');
                 $('#responsibleAccountNumberEntryField').val('');
                 $('#responsibleAccountAmountEntryField').val('');
+                modal.modal('hide');
             },
             error: function (xhr) {
                 var msg = 'Error occurred';
                 if (xhr.responseJSON) {
                     msg = xhr.responseJSON.Message || xhr.responseJSON.message || msg;
+                }
+                if (typeof msg === 'string' && msg.toLowerCase().includes('already exists')) {
+                    msg = 'Responsibility Fixed';
                 }
                 alert(msg);
             }


### PR DESCRIPTION
## Summary
- reset responsibility grids and replace 'Already Exists' messages with 'Responsibility Fixed'
- reload responsibility sections after modal closes across branch management views

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688cef89fc0c832e91e4468353176dc5