### PR TITLE
Refresh responsibility lists after updates

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -43,7 +43,8 @@
             tableSelector: '#viewMemo_respPP_ObSent',
             modalSelector: '#ResponsiblePPModel',
             status: 4,
-            directSaveMode: false
+            directSaveMode: false,
+            afterSave: function () { respSection.reload(); }
         });
 
          document.getElementById('viewMemo_amount_ObSent').addEventListener('input', function (e) {

--- a/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
+++ b/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
@@ -31,7 +31,8 @@
             tableSelector: '#viewMemo_respPP_ObSent',
             modalSelector: '#ResponsiblePPModel',
             status: 2,
-            directSaveMode: false
+            directSaveMode: false,
+            afterSave: function () { respSection.reload(); }
         });
 
 

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -52,7 +52,8 @@
             changesTableSelector: '#c_update_listofRespPersons',
             modalSelector: '#ResponsiblePPModel',
             status: 1,
-            directSaveMode: false
+            directSaveMode: false,
+            afterSave: function () { respSectionView.reload(); }
         });
     });
     function reloadLocation() {

--- a/AIS/AIS/wwwroot/js/responsibilitySection.js
+++ b/AIS/AIS/wwwroot/js/responsibilitySection.js
@@ -9,7 +9,8 @@ function initResponsibilitySection(config) {
         indicator: '',
         readOnly: false,
         status: 0,
-        directSaveMode: true
+        directSaveMode: true,
+        afterSave: null
     }, config || {});
 
     var table = $(opts.tableSelector);
@@ -244,6 +245,9 @@ function initResponsibilitySection(config) {
                 alert(msg);
                 modal.modal('hide');
                 load();
+                if (typeof opts.afterSave === 'function') {
+                    opts.afterSave();
+                }
                 $('#matchedPPNoPanels').empty();
                 $('#matchedPPNoPanelsBYPP').empty();
                 $('#responsiblePPNoEntryField').val('');


### PR DESCRIPTION
## Summary
- add afterSave callback in responsibilitySection.js to allow external reload after responsibility operations
- use afterSave in manage_observations_branches, manage_draft_report_paras_branch, and draft_audit_report_branch to refresh responsibility grids

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688cf3c7312c832e81768456ea587838