### PR TITLE
Reload responsibility sections after alerts

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -24,6 +24,7 @@
     var g_subProcId=0;
     var g_procDetailId=0;
     var g_selectedRiskId = 0;
+    var g_statusId = 0;
     var respSection = null;
     var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
     $(document).ready(function () {
@@ -44,7 +45,10 @@
             modalSelector: '#ResponsiblePPModel',
             status: 4,
             directSaveMode: false,
-            afterSave: function () { respSection.reload(); }
+            afterSave: function () {
+                respSection.reload();
+                viewObservationDetails(g_obsId, g_statusId);
+            }
         });
 
          document.getElementById('viewMemo_amount_ObSent').addEventListener('input', function (e) {
@@ -196,6 +200,7 @@
     }
     function viewObservationDetails(obsId,status_id){
         g_obsId=obsId;
+        g_statusId = status_id;
         $('#viewMemoDetailsModel').modal('show');
 
 

--- a/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
+++ b/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
@@ -32,7 +32,10 @@
             modalSelector: '#ResponsiblePPModel',
             status: 2,
             directSaveMode: false,
-            afterSave: function () { respSection.reload(); }
+            afterSave: function () {
+                respSection.reload();
+                ViewObservation(g_obsId);
+            }
         });
 
 

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -53,7 +53,10 @@
             modalSelector: '#ResponsiblePPModel',
             status: 1,
             directSaveMode: false,
-            afterSave: function () { respSectionView.reload(); }
+            afterSave: function () {
+                respSectionView.reload();
+                ObservationUpdatePanel(g_obsId);
+            }
         });
     });
     function reloadLocation() {

--- a/AIS/AIS/wwwroot/js/responsibilitySection.js
+++ b/AIS/AIS/wwwroot/js/responsibilitySection.js
@@ -243,11 +243,13 @@ function initResponsibilitySection(config) {
             success: function (data) {
                 var msg = data.Message || data.message || 'Operation completed';
                 alert(msg);
-                modal.modal('hide');
-                load();
-                if (typeof opts.afterSave === 'function') {
-                    opts.afterSave();
-                }
+                onAlertCallback(function () {
+                    modal.modal('hide');
+                    load();
+                    if (typeof opts.afterSave === 'function') {
+                        opts.afterSave();
+                    }
+                });
                 $('#matchedPPNoPanels').empty();
                 $('#matchedPPNoPanelsBYPP').empty();
                 $('#responsiblePPNoEntryField').val('');


### PR DESCRIPTION
## Summary
- Delay responsibility section reloads until after alert dismissal, ensuring updated lists.
- Refresh observation and draft report modals once responsibility updates complete.
- Reopen and refresh observation update panel after responsibility changes.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688cffd4b144832e81af2bef78edf92d