### PR TITLE
Add field observation view with status-based controls

### DIFF
--- a/AIS/AIS/Controllers/ExecutionController.cs
+++ b/AIS/AIS/Controllers/ExecutionController.cs
@@ -470,6 +470,28 @@ namespace AIS.Controllers
                     return View();
                 }
             }
+        public IActionResult Manage_obervation_field(int engId = 0)
+            {
+            ViewData["TopMenu"] = tm.GetTopMenus();
+            ViewData["TopMenuPages"] = tm.GetTopMenusPages();
+            ViewData["EntitiesList"] = dBConnection.GetObservationEntitiesForManageObservations();
+            ViewData["ProcessList"] = dBConnection.GetAuditChecklistCAD();
+            ViewData["AnnexList"] = dBConnection.GetAnnexuresForChecklistDetail();
+            ViewData["RiskList"] = dBConnection.GetRisks();
+            if (!sessionHandler.IsUserLoggedIn())
+                {
+                return RedirectToAction("Index", "Login");
+                }
+            else
+                {
+                if (!sessionHandler.HasPermissionToViewPage(MethodBase.GetCurrentMethod().Name))
+                    {
+                    return RedirectToAction("Index", "PageNotFound");
+                    }
+                else
+                    return View();
+                }
+            }
         public IActionResult manage_draft_report_paras(int engId = 0)
             {
             ViewData["TopMenu"] = tm.GetTopMenus();

--- a/AIS/AIS/Views/Execution/Manage_obervation_field.cshtml
+++ b/AIS/AIS/Views/Execution/Manage_obervation_field.cshtml
@@ -1,0 +1,1112 @@
+﻿@{
+    ViewData["Title"] = "Manage Observation Field";
+    Layout = "_Layout";
+}
+<style type="text/css">
+    .evidence-link {
+        display: flex;
+        align-items: center;
+        margin-bottom: 10px;
+    }
+
+    .evidence-icon {
+        margin-right: 10px;
+    }
+</style>
+
+
+<script type="text/javascript">
+    var g_obsId = 0;
+    var g_entityID = 0;
+    var g_newStatusId = 0;
+    var g_riskId = 0;
+    var g_annexId = 0;
+    var g_currentStatus = 0;
+    var g_obsList = [];
+    var g_selectedRiskId = 0;
+    var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
+    var respSectionView = null;
+    var respSectionUpdate = null;
+    var g_referenceUpdated = false;
+    $(document).ready(function () {
+        $('#entitySelectField').select2();
+        var entName = $('#manageObsPanel tbody .entity_name_field:first').text();
+        $('#entityNameField').val(entName);
+        var periodName = $('#manageObsPanel tbody .period_name_field:first').text();
+        $('#auditPeriodNameField').val(periodName);
+
+        $('#updateMemoContent').richText({
+            imageUpload: false,
+            fileUpload: false,
+            videoEmbed: false,
+            urls: false
+        });
+        $('#updateMemo_annex').on('change', updateRiskDisplay);
+        respSectionView = initResponsibilitySection({
+            tableSelector: '#listofRespPersons',
+            readOnly: true,
+            status: 1,
+            directSaveMode: false
+        });
+        respSectionUpdate = initResponsibilitySection({
+            tableSelector: '#update_listofRespPersons',
+            changesTableSelector: '#c_update_listofRespPersons',
+            modalSelector: '#ResponsiblePPModel',
+            status: 1,
+            directSaveMode: false,
+            afterSave: function () {
+                respSectionView.reload();
+                ObservationUpdatePanel(g_obsId);
+            }
+        });
+    });
+    function reloadLocation() {
+        getEntityObservation();
+    }
+    function getEntityObservation() {
+        destroyDatatable('manageObsPanel');
+        if ($('#entitySelectField option:selected').val() != 0) {
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/get_observation_branches",
+                type: "POST",
+                data: {
+                    'ENG_ID': $('#entitySelectField option:selected').val()
+                },
+                cache: false,
+                success: function (data) {
+                    g_obsList = data;
+                    $.each(data, function (i, v) {
+                        g_entityID=v.entitY_ID;
+                        $('#auditPeriodNameField').val(v.period);
+                        $('#manageObsPanel tbody').append(' <tr id="' + v.obS_ID + '"><td class="text-center">' + v.memO_NO + '</td><td class="text-center">' + v.annexurE_CODE + '</td><td>' + v.heading + '</td><td>' + v.nO_OF_INSTANCES + '</td><td>' + v.obS_RISK + '</td><td>' + v.obS_STATUS + '</td><td class="text-center"><a onclick="event.preventDefault();ObservationViewerPanel(' + v.obS_ID + ',' + v.obS_STATUS_ID + ', ' + v.obS_RISK_ID + ', ' + v.annexurE_ID + ')" href="#" class="text-hover">View Memo</a></td><td><a onclick="ObservationUpdatePanel(' + v.obS_ID + ')" href="#" class="text-hover">Update Memo</a></td></tr>');
+                    });
+
+                    initializeDataTable('manageObsPanel');
+
+                    setTimeout(function () {
+                        if (g_obsId != 0) {
+                            var rowpos = $('#manageObsPanel tbody tr#' + g_obsId).position();
+                            $('html').scrollTop(rowpos.top);
+                        }
+                    }, 200)
+                },
+                dataType: "json",
+            });
+
+        }
+    }
+    function getSubProcessList() {
+        if ($('#updateMemo_process option:selected').val() == 0) {
+            $('#updateMemo_subprocess').empty();
+            $('#updateMemo_violation').empty();
+        }
+        else {
+
+            $('#updateMemo_subprocess').empty();
+            $('#updateMemo_violation').empty();
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/sub_checklist",
+                type: "POST",
+                data: {
+                    'T_ID': $('#updateMemo_process option:selected').val(),
+                },
+                cache: false,
+                success: function (data) {
+                    $('#updateMemo_subprocess').append("<option value=\"0\" id=\"0\">--Select Sub Group--</option>");
+                    $.each(data, function (index, item) {
+                        $('#updateMemo_subprocess').append("<option value=\"" + item.s_ID + "\"> " + item.heading + " </option > ");
+                    });
+
+                },
+                dataType: "json",
+            });
+        }
+    }
+    function getSubProcessViolationList() {
+        if ($('#updateMemo_subprocess option:selected').val() == 0)
+            $('#updateMemo_violation').empty();
+        else {
+            $('#updateMemo_violation').empty();
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/checklist_details",
+                type: "POST",
+                data: {
+                    'S_ID': $('#updateMemo_subprocess option:selected').val(),
+                },
+                cache: false,
+                success: function (data) {
+                    $('#updateMemo_violation').append("<option value=\"0\" id=\"0\">--Select Sub Group--</option>");
+                    $.each(data, function (index, item) {
+                        $('#updateMemo_violation').append("<option value=\"" + item.id + "\"> " + item.heading + "</option>");
+                    });
+
+                },
+                dataType: "json",
+            });
+        }
+
+
+    }
+    function updateRiskDisplay() {
+        var annexId = $('#updateMemo_annex').val();
+        var riskName = '';
+        g_selectedRiskId = 0;
+        $.each(g_annexList, function (i, v) {
+            var id = v.ID || v.id;
+            if (id == annexId) {
+                riskName = v.RISK || v.risk;
+                g_selectedRiskId = v.RISK_ID || v.risK_ID;
+            }
+        });
+        $('#updateMemo_risk_display').val(riskName);
+        var color = '';
+        if (riskName.toLowerCase() === 'high') {
+            color = 'red';
+        } else if (riskName.toLowerCase() === 'medium') {
+            color = 'gold';
+        } else if (riskName.toLowerCase() === 'low') {
+            color = 'green';
+        }
+        $('#updateMemo_risk_display').css('color', color);
+    }
+    function ObservationViewerPanel(obs_id, status_id, risk_id, anxId) {
+        g_obsId = obs_id;
+        g_riskId = risk_id;
+        g_annexId=anxId;
+        g_currentStatus = status_id;
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/get_observation_text_branches",
+            type: "POST",
+            data: {
+                'OBS_ID': obs_id
+            },
+            cache: false,
+            success: function (data) {
+                $('#viewMemoModel').modal('show');
+                $('#viewMemo_memo').html(data[0].obS_TEXT);
+                $('#viewMemo_response').html(data[0].obS_REPLY);
+
+
+                $('#viewMemo_annex').val(data[0].annexurE_ID);
+                $('#viewMemo_risk').val(data[0].obS_RISK_ID);
+
+                $('#viewMemo_process').html(data[0].process);
+                $('#viewMemo_subprocess').html(data[0].suB_PROCESS);
+                $('#viewMemo_violation').html(data[0].checklist_Details);
+                
+                if (g_currentStatus == 1) {
+                    $('#dropButton_memoReply').removeClass('d-none');
+                    $('#submitAuditeeButton_memoReply').removeClass('d-none');
+                }
+                else if (g_currentStatus == 3) {
+                    if (g_riskId == 3) {
+                        $('#dropButton_memoReply').addClass('d-none');
+                        $('#submitAuditeeButton_memoReply').addClass('d-none');
+                    }
+                    else {
+                        $('#dropButton_memoReply').addClass('d-none');
+                        $('#submitAuditeeButton_memoReply').addClass('d-none');
+                    }
+                }
+                else {
+                    $('#dropButton_memoReply').addClass('d-none');
+                    $('#submitAuditeeButton_memoReply').addClass('d-none');
+                }
+                $('#complianceCycleEvidences').empty();
+                if(data[0].attacheD_EVIDENCES != null){
+                if (data[0].attacheD_EVIDENCES.length > 0) {
+                    $.each(data[0].attacheD_EVIDENCES, function (i, pp) {
+                        var extension = pp.imagE_NAME.split('.').pop().toLowerCase();
+                        const contentType = getContentType(extension);
+                        // Create and append the attachment item
+                        const container = document.createElement('div');
+                        container.className = 'evidence-link';
+
+                        // Add icon
+                        const icon = document.createElement('i');
+                        icon.className = getIconClass(extension) + ' evidence-icon mr-1';
+                        container.appendChild(icon);
+
+                        // Add label
+                        const label = document.createElement('span');
+                        label.innerText = pp.imagE_NAME;
+                        label.classList.add('text-primary');
+
+                        // Add cursor style to make it look like a link
+                        label.style.cursor = 'pointer';
+                        container.appendChild(label);
+
+                        // Add click event to download file on selection
+                        container.addEventListener('click', function () {
+                            downloadFile(pp.filE_ID);
+                        });
+
+                        $('#complianceCycleEvidences').append(container);
+                    });
+                }
+                }else {
+                    $('#complianceCycleEvidences').append("<i>No evidence is attached </i>");
+                }
+                initReferenceSection(obs_id, true, '#viewMemoModel #referenceSection');
+                respSectionView.updateContext({ newParaId: obs_id });
+            },
+            dataType: "json",
+        });
+
+    }
+    function ObservationUpdatePanel(obs_id) {
+        g_obsId = obs_id;
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/get_observation_text_branches",
+            type: "POST",
+            data: {
+                'OBS_ID': obs_id
+            },
+            cache: false,
+            success: function (data) {
+                $('#updateMemoModel').modal('show');
+                $('#updateMemoContent').val(data[0].obS_TEXT).trigger('change');
+                $('#updateMemo_heading').val(data[0].heading);
+                $('#updateMemo_process').val(data[0].procesS_ID);
+                $('#updateMemo_annex').val(data[0].annexurE_ID);
+                g_selectedRiskId = data[0].obS_RISK_ID;
+                g_currentStatus = data[0].obS_STATUS_ID;
+                g_annexId = data[0].annexurE_ID;
+                g_referenceUpdated = false;
+                $('#confirmUpdateBtn').removeClass('d-none');
+                $('#actionButtons').addClass('d-none');
+                updateRiskDisplay();
+                $('#updateMemo_subprocess').empty();
+                $('#updateMemo_subprocess').append('<option value="0">' + data[0].suB_PROCESS + '</option>');
+                $('#updateMemo_violation').empty();
+                $('#updateMemo_violation').append('<option value="0">' + data[0].checklist_Details + '</option>');
+                $('#listofRespPersons tbody').empty();
+                if(data[0].responsiblE_PPs != null){
+                    if (data[0].responsiblE_PPs.length > 0) {
+                    $.each(data[0].responsiblE_PPs, function (j, pp) {
+                        var srNo = $('#listofRespPersons tbody tr').length;
+                        srNo++;
+                        $('#listofRespPersons tbody').append('<tr id="tr_' + pp.pP_NO + '"><td>' + srNo + '</td><td>' + pp.pP_NO + '</td><td>' + pp.emP_NAME + '</td><td>' + pp.loaN_CASE + '</td><td>' + pp.lC_AMOUNT + '</td><td>' + pp.accounT_NUMBER + '</td><td>' + pp.acC_AMOUNT + '</td></tr>');
+                    });
+                }
+                }
+                initReferenceSection(obs_id, false, '#updateMemoModel #referenceSection');
+                $('#updateMemoModel #referenceSection').off('referenceSectionSaved').on('referenceSectionSaved', function () {
+                    g_referenceUpdated = true;
+                });
+                if (g_currentStatus > 2) {
+                    $('#auditeeReplyGroup').removeClass('d-none');
+                    $('#updateMemo_auditeeReply').val(data[0].obS_REPLY).prop('readonly', true);
+                } else {
+                    $('#auditeeReplyGroup').addClass('d-none');
+                    $('#updateMemo_auditeeReply').val('');
+                }
+                respSectionUpdate.updateContext({ newParaId: obs_id });
+            },
+            dataType: "json",
+        });
+
+    }
+    function finalCommentsButtonSave() {
+        if ($('#commentAreaInCommentsBox').val() == "") {
+            alert("Auditor Comments are Mandatory");
+            return;
+        }
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/update_observation_status",
+            type: "POST",
+            data: {
+                'OBS_ID': g_obsId,
+                'NEW_STATUS_ID': g_newStatusId,
+                'RISK_ID': g_riskId,
+                'AUDITOR_COMMENT': $('#commentAreaInCommentsBox').val()
+            },
+            cache: false,
+            success: function (data) {
+                if (data.Status == true) {
+                    alert(data.Message);
+                    onAlertCallback(reloadLocation);
+                } else {
+                    alert("Failed!! please try again");
+                    onAlertCallback(reloadLocation);
+                }
+            },
+            dataType: "json",
+        });
+    }
+    function updateObservationStatus(obs_id, new_status_id, risk_id) {
+        g_obsId = obs_id;
+        g_newStatusId = new_status_id;
+        g_riskId = risk_id;
+        $('#commentsBox').modal('show');
+        $('#commentAreaInCommentsBox').val('');
+    }
+    function dropObservation(obs_id, new_status_id, risk_id) {
+        g_obsId = obs_id;
+        g_newStatusId = new_status_id;
+        g_riskId = risk_id;
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/drop_observation",
+            type: "POST",
+            data: {
+                'OBS_ID': g_obsId,
+                'NEW_STATUS_ID': g_newStatusId,
+                'RISK_ID': g_riskId
+            },
+            cache: false,
+            success: function (data) {
+                alert(data.Message);
+                onAlertCallback(reloadLocation);
+            },
+            dataType: "json",
+        });
+    }
+    function submitObservationToAuditee(obs_id, new_status_id, risk_id) {
+        g_obsId = obs_id;
+        g_newStatusId = new_status_id;
+        g_riskId = risk_id;
+
+        if (g_annexId === 1) {
+            // Close the viewer modal before opening the DSA modal to
+            // avoid overlapping backdrops which disabled the page.
+            $('#viewMemoModel').modal('hide');
+            $('#DSAModel').modal('show');
+
+            $.each(g_obsList, function (i, v) {
+                if (v.obS_ID == obs_id) {
+                    $('#dsaHeading').val(v.heading);
+
+                    $.ajax({
+                        url: g_asiBaseURL + "/ApiCalls/get_observation_text_branches",
+                        type: "POST",
+                        data: {
+                            'OBS_ID': obs_id
+                        },
+                        cache: false,
+                        success: function (data) {
+                            $('#dsaContent').html(data[0].obS_TEXT);
+                            $('#dsaResponsibles tbody').empty();
+
+                            if (data[0].responsiblE_PPs && data[0].responsiblE_PPs.length > 0) {
+                                $.each(data[0].responsiblE_PPs, function (j, pp) {
+                                    var srNo = $('#dsaResponsibles tbody tr').length + 1;
+                                    $('#dsaResponsibles tbody').append('<tr id="tr_' + pp.pP_NO + '"><td>' + srNo + '</td><td>' + pp.pP_NO + '</td><td>' + pp.emP_NAME + '</td><td>' + pp.loaN_CASE + '</td><td>' + pp.lC_AMOUNT + '</td><td>' + pp.accounT_NUMBER + '</td><td>' + pp.acC_AMOUNT + '</td><td><input class="chk_dsaissued" resp_row_id="' + pp.resP_ROW_ID + '" id="' + pp.pP_NO + '" type="checkbox" /></td></tr>');
+                                });
+                            }
+                        },
+                        dataType: "json",
+                    });
+                }
+            });
+        } else {
+            finalSubmissionParasToAuditee();
+        }
+    }
+    function submitObservationToAuditeeAfterDSAIssuance(){
+        var dsaArr=[];
+
+        $.each($('.chk_dsaissued'), function(i,v){
+            if($(v).is(":checked"))
+            {
+                dsaArr.push({"RESP_ROW_ID":$(v).attr("resp_row_id"),"RESP_PP_NO":$(v).attr("id")});
+            }
+    });
+
+    if(dsaArr.length==0){
+        alert("This Observation is marked with A-1 annexure, therefore, please select at least one responsible from the list to issue DSA");
+        return false;
+    }
+
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/submit_dsa_to_auditee",
+                type: "POST",
+                data: {
+                    'OBS_ID': g_obsId,
+                    'ENTITY_ID': g_entityID,
+                    'ENG_ID': $('#entitySelectField').val(),
+                    "RespDSAModel":dsaArr
+                },
+                cache: false,
+                success: function (data) {
+                    alert(data.Message);
+                   onAlertCallback(finalSubmissionParasToAuditee);
+                    $('#DSAModel').modal('hide');
+                    $('#viewMemoModel').modal('hide');
+                    $('#submitAuditeeButton_memoReply').removeAttr('disabled');
+                },
+                dataType: "json",
+            });
+
+    }
+    function finalSubmissionParasToAuditee(){
+
+         $('#submitAuditeeButton_memoReply').attr('disabled', 'disabled');
+            $.ajax({
+                url: g_asiBaseURL + "/ApiCalls/submit_observation_to_auditee",
+                type: "POST",
+                data: {
+                    'OBS_ID': g_obsId,
+                    'NEW_STATUS_ID': g_newStatusId,
+                    'RISK_ID': g_riskId
+                },
+                cache: false,
+                success: function (data) {
+                    alert(data.Message);
+                    onAlertCallback(reloadLocation);
+                    $('#DSAModel').modal('hide');
+                    $('#viewMemoModel').modal('hide');
+                    $('#submitAuditeeButton_memoReply').removeAttr('disabled');
+                },
+                dataType: "json",
+            });
+    }
+    function confirmDetailUpdates() {
+        if (!g_referenceUpdated) {
+            alert("Please update and save the Reference section first.");
+            return;
+        }
+        if (!confirm("Have you completed updates to annexure, process, sub-process, checklist detail, para title, para text and responsibles?")) {
+            return;
+        }
+        $('#confirmUpdateBtn').addClass('d-none');
+        showActionButtons();
+    }
+    function showActionButtons() {
+        $('#actionButtons').removeClass('d-none');
+        $('#btnUpdatePara, #btnDropPara, #btnSubmitAuditee, #btnAddDraft, #btnSettled').addClass('d-none');
+        if (g_currentStatus < 8) $('#btnUpdatePara').removeClass('d-none');
+        if (g_currentStatus == 1) {
+            $('#btnDropPara').removeClass('d-none');
+            $('#btnSubmitAuditee').removeClass('d-none');
+        }
+        if (g_currentStatus == 4) {
+            $('#btnAddDraft').removeClass('d-none');
+            $('#btnSettled').removeClass('d-none');
+        }
+    }
+    function updateParaStatus(statusId) {
+        if (!g_referenceUpdated) {
+            alert("Please update and save the Reference section first.");
+            return;
+        }
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/update_observation_status",
+            type: "POST",
+            data: {
+                'OBS_ID': g_obsId,
+                'NEW_STATUS_ID': statusId,
+                'RISK_ID': g_selectedRiskId
+            },
+            cache: false,
+            success: function (data) {
+                alert(data.Message);
+                onAlertCallback(reloadLocation);
+            },
+            dataType: "json",
+        });
+    }
+    function addToDraft() {
+        updateParaStatus(5);
+    }
+    function settleObservation() {
+        updateParaStatus(8);
+    }
+    function finalUpdateMemoContent(obs_id) {
+        if (!g_referenceUpdated) {
+            alert("Please update and save the Reference section first.");
+            return;
+        }
+        g_obsId = obs_id;
+        updateRiskDisplay();
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/update_observation_text",
+            type: "POST",
+            data: {
+                'OBS_ID': g_obsId,
+                'OBS_TITLE': $('#updateMemo_heading').val(),
+                'OBS_TEXT': $('.richText-editor').html(),
+                'ANNEXURE_ID': $('#updateMemo_annex').val(),
+                'RISK_ID': g_selectedRiskId,
+                'PROCESS_ID': $('#updateMemo_process').val(),
+                'SUBPROCESS_ID': $('#updateMemo_subprocess').val(),
+                'CHECKLIST_ID': $('#updateMemo_violation').val()
+            },
+            cache: false,
+            success: function (data) {
+                alert(data.Message);
+                onAlertCallback(reloadLocation);
+            },
+            dataType: "json",
+        });
+
+    }
+    function openResponsiblePPs() {
+        $('#ResponsiblePPModel').modal('show');
+    }
+    function addResponsibilityToMainTable(action) {
+        respSectionUpdate.saveResp(action);
+    }
+    function downloadFile(id) {
+        $.ajax({
+            url: g_asiBaseURL + "/ApiCalls/get_auditee_evidence_data",
+            type: "POST",
+            data: {
+                'FILE_ID': id,
+            },
+            cache: false,
+            success: function (data) {
+                var extension = data.imagE_NAME.split('.').pop().toLowerCase();
+                const contentType = getContentType(extension);
+
+                const blob = base64ToBlob(data.imagE_DATA, contentType);
+                const link = document.createElement('a');
+                link.href = URL.createObjectURL(blob);
+                link.download = data.imagE_NAME;
+                link.click(); // Trigger the download
+
+            },
+            dataType: "json",
+        });
+
+
+    }
+    function getFileExtension(file) {
+        var fileName = file.name;
+        var extension = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
+        return extension;
+    }
+    function getIconClass(extension) {
+        switch (extension) {
+            case 'pdf': return 'fa fa-file-pdf';
+            case 'zip': return 'fa fa-file-archive';
+            case 'png':
+            case 'jpg':
+            case 'jpeg':
+            case 'bmp': return 'fa fa-file-image';
+            case 'doc':
+            case 'docx': return 'fa fa-file-word';
+            default: return 'fa fa-file';
+        }
+    }
+    function getContentType(extension) {
+        switch (extension) {
+            case 'pdf': return 'application/pdf';
+            case 'zip': return 'application/zip';
+            case 'png': return 'image/png';
+            case 'doc': return 'application/msword';
+            case 'docx': return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+            default: return 'application/octet-stream';
+        }
+    }
+    function base64ToBlob(base64, contentType) {
+        const byteCharacters = atob(base64);
+        const byteArrays = [];
+
+        for (let offset = 0; offset < byteCharacters.length; offset += 512) {
+            const slice = byteCharacters.slice(offset, offset + 512);
+
+            const byteNumbers = new Array(slice.length);
+            for (let i = 0; i < slice.length; i++) {
+                byteNumbers[i] = slice.charCodeAt(i);
+            }
+
+            const byteArray = new Uint8Array(byteNumbers);
+            byteArrays.push(byteArray);
+        }
+
+        const blob = new Blob(byteArrays, { type: contentType });
+        return blob;
+    }
+</script>
+
+<div class="row">
+    <div class="col-md-12 mt-3">
+        <h3 style=" display:block;color: #45c545;">Manage Audit Observations</h3>
+    </div>
+    <div class="row col-md-12 mt-3">
+        <div class="col-md-2">
+            <label><b>Entity:</b></label>
+        </div>
+        <div class="col-md-10">
+            <input id="entityNameField" disabled="disabled" class="form-control ml-1 d-none" type="text" />
+            <select id="entitySelectField" onchange="getEntityObservation()" class="form-control form-select">
+                <option value="0" id="0">--Select Audit Entity--</option>
+                @{
+                    if (ViewData["EntitiesList"] != null)
+                    {
+                        foreach (var item in (dynamic)(ViewData["EntitiesList"]))
+                        {
+                            <option value="@item.ENG_ID" id="@item.ENG_ID">@item.NAME</option>
+                        }
+                    }
+                }
+
+            </select>
+        </div>
+    </div>
+    <div class="row col-md-12 mt-3">
+        <div class="col-md-2">
+            <label><b>Audit Period:</b></label>
+        </div>
+        <div class="col-md-10 ">
+            <input id="auditPeriodNameField" disabled="disabled" class="form-control ml-1" type="text" />
+        </div>
+    </div>
+    <div class="row col-md-12 mt-3">
+        <table id="manageObsPanel" class="table table-hover table-bordered table-hover mt-3 table-striped">
+            <thead style="background-color: #19875478 !important; ">
+                <tr>
+                    <th class="col-md-auto">Memo No.</th>
+                    <th class="col-md-auto">Annexure</th>
+                    <th class="col-md-auto">Title of Observation</th>
+                    <th class="col-md-auto">No. of Instances</th>
+                    <th class="col-md-auto">Risk Category</th>
+                    <th class="col-md-auto">Status</th>
+                    <th class="col-md-auto text-center"></th>
+                    <th class="col-md-auto text-center"></th>
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+
+        </table>
+    </div>
+
+</div>
+<div id="commentsBox" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-danger text-white">
+                <h5 class="modal-title">Auditor Comments</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group">
+                        <label for="commentAreaInCommentsBox">Comments</label>
+                        <textarea class="form-control" rows="4" id="commentAreaInCommentsBox" placeholder="Enter Comments here.."></textarea>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                <button onclick="finalCommentsButtonSave();" id="finalCommentsButtonSave" type="button" class="btn btn-danger">Submit</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="viewMemoModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-danger text-white">
+                <h5 class="modal-title">Observation</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group mb-3">
+                        <label for="viewMemo_annex" class="font-weight-bold">Annexure</label>
+                        <select id="viewMemo_annex" disabled="disabled" class="form-select form-control">
+                            <option selected="selected" value="0" id="0">--Select Annexure--</option>
+                            @{
+                                if (ViewData["AnnexList"] != null)
+                                {
+
+                                    foreach (var item in (dynamic)(ViewData["AnnexList"]))
+                                    {
+                                        <option id="@item.ID" value="@item.ID">@item.ANNEX</option>
+                                    }
+
+                                }
+                            }
+
+                        </select>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="viewMemo_risk">Risk</label>
+                        <select id="viewMemo_risk" disabled="disabled" class="form-select form-control" aria-label="Default select example">
+                            <option value="0" id="0" selected>--Select Risk Category--</option>
+                            @{
+                                if (ViewData["RiskList"] != null)
+                                {
+                                    foreach (var risk in (dynamic)(ViewData["RiskList"]))
+                                    {
+                                        <option id="@risk.R_ID" value="@risk.R_ID">@risk.DESCRIPTION</option>
+                                    }
+
+                                }
+                            }
+                        </select>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="viewMemo_process" class="font-weight-bold">Process</label>
+                        <div id="viewMemo_process" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="viewMemo_subprocess" class="font-weight-bold">Sub Process</label>
+                        <div id="viewMemo_subprocess" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="viewMemo_violation" class="font-weight-bold">Checklist Details</label>
+                        <div id="viewMemo_violation" disabled="disabled" style="max-height: 100px; height: auto; overflow-y: auto;" class="form-control"></div>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="viewMemo_memo" class="font-weight-bold">Memo</label>
+                        <div id="viewMemo_memo" disabled="disabled" style="height: auto; overflow-y: auto;" class="form-control"></div>
+                    </div>
+                    <div id="referenceSection" class="mt-3 p-3 border border-danger mb-3">
+                        <h6>References</h6>
+                        <ul id="refList" class="list-group mb-3"></ul>
+                        <button type="button" class="btn btn-success mb-3" id="saveBtn">Save</button>
+                        <div id="searchSection">
+                            <select id="refType" class="form-select mb-2">
+                                <option value="0" selected>Please select reference</option>
+                                <option value="Manual">Manual</option>
+                                <option value="Policy">Policy</option>
+                                <option value="Circular">Circular</option>
+                            </select>
+                            <div id="searchInputs" style="display:none;">
+                                <input id="keyword" class="form-control mb-2" placeholder="keyword" />
+                                <button type="button" class="btn btn-primary" id="searchBtn">Search</button>
+                            </div>
+                            <div id="manualInputs" style="display:none;">
+                                <input id="manualName" class="form-control mb-2" placeholder="Manual/Policy Name" />
+                                <input id="chapterSection" class="form-control mb-2" placeholder="Chapter No + Section" />
+                                <button type="button" class="btn btn-primary" id="addManualBtn">Add</button>
+                            </div>
+                        </div>
+                        <table class="table" id="resultTbl" style="display:none;">
+                            <thead>
+                                <tr>
+                                    <th>TITLE</th>
+                                    <th>REFERENCE ID</th>
+                                    <th>INSTRUCTIONS DETAILS</th>
+                                    <th>KEYWORDS</th>
+                                    <th>View Circular</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                    
+                    <div class="form-group">
+                        <label for="viewMemo_respPP" class="font-weight-bold">Responsible Personals</label>
+                        <div class="col-md-12 pl-0 pr-0">
+                            <table id="listofRespPersons" class="table table-hover table-bordered table-hover mt-3 table-striped">
+                                <thead style="background-color: #19875478 !important; ">
+                                    <tr>
+                                        <th class="col-md- auto font-weight-bold">Sr.No</th>
+                                        <th class="col-md- auto font-weight-bold">P.P. No</th>
+                                        <th class="col-md- auto font-weight-bold">Name</th>
+                                        <th class="col-md- auto font-weight-bold">Loan Case</th>
+                                        <th class="col-md- auto font-weight-bold">LC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Account No.</th>
+                                        <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="viewMemo_response" class="font-weight-bold">Auditee Response</label>
+                        <div id="viewMemo_response" disabled="disabled" style="height: auto; overflow-y: auto;" class="form-control"></div>
+                    </div>
+                    <div id="evidenceViewer" class="input-field">
+                        <label class="font-weight-bold">Evidences</label>
+                        <div class="row col-md-12 mt-3 mb-3">
+                            <div id="complianceCycleEvidences">
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button id="dropButton_memoReply" onclick="dropObservation(g_obsId,7,g_riskId);" type="button" data-bs-dismiss="modal" class="btn btn-danger d-none">Drop Observation</button>
+                <button id="submitAuditeeButton_memoReply" onclick="submitObservationToAuditee(g_obsId, 2, g_riskId);" type="button" data-bs-dismiss="modal" class="btn btn-danger d-none">Submit to Auditee</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="updateMemoModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-danger text-white">
+                <h5 class="modal-title">Update Observation</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group mb-3">
+                        <label>Annexure</label>
+                        <div class="row col-md-12 w-100 m-0 p-0">
+                            <select id="updateMemo_annex" class="form-select form-control">
+                                <option selected="selected" value="0" id="0">--Select Annexure--</option>
+                                @{
+                                    if (ViewData["AnnexList"] != null)
+                                    {
+
+                                        foreach (var item in (dynamic)(ViewData["AnnexList"]))
+                                        {
+                                            <option id="@item.ID" value="@item.ID">@item.ANNEX</option>
+                                        }
+
+                                    }
+                                }
+
+                            </select>
+                        </div>
+
+                    </div>
+
+                    <div class="form-group mb-3">
+                        <label for="updateMemo_risk_display">Risk will be assigned on the basis of Selected Annexure</label>
+                        <input id="updateMemo_risk_display" class="form-control" readonly />
+                    </div>
+
+                    <div class="form-group mb-3">
+                        <label for="updateMemo_process" class="font-weight-bold">Process</label>
+                        <select id="updateMemo_process" onchange="getSubProcessList();" class="form-select form-control" aria-label="Default select example">
+                            <option value="0" id="0" selected="selected">--Select Voilation Category--</option>
+                            @{
+                                if (ViewData["ProcessList"] != null)
+                                {
+                                    foreach (var item in (dynamic)(ViewData["ProcessList"]))
+                                    {
+                                        <option id="@item.T_ID" value="@item.T_ID">@item.HEADING</option>
+                                    }
+                                }
+                            }
+                        </select>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="updateMemo_subprocess" class="font-weight-bold">Sub Process</label>
+                        <select id="updateMemo_subprocess" onchange="getSubProcessViolationList();" class="form-select form-control" aria-label="Default select example">
+                        </select>
+
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="updateMemo_violation" class="font-weight-bold">Checklist Details</label>
+                        <select id="updateMemo_violation" class="form-select form-control" aria-label="Default select example">
+                        </select>
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="updateMemo_heading" class="font-weight-bold">Title / Heading</label>
+                        <input id="updateMemo_heading" class="form-control" />
+                    </div>
+                    <div class="form-group mb-3">
+                        <label for="updateMemoContent" class="font-weight-bold">Memo</label>
+                        <textarea id="updateMemoContent" rows="5" class="form-control">
+
+                        </textarea>
+                    </div>
+                    <div id="auditeeReplyGroup" class="form-group mb-3 d-none">
+                        <label for="updateMemo_auditeeReply" class="font-weight-bold">Auditee Reply</label>
+                        <textarea id="updateMemo_auditeeReply" rows="5" class="form-control" readonly></textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="update_listofRespPersons" class="font-weight-bold">Responsible Personals</label>
+                        <div class="row col-sm-12">
+                            <table id="update_listofRespPersons" class="table table-hover table-bordered table-hover mt-3 table-striped">
+                                <thead style="background-color: #19875478 !important; ">
+                                    <tr>
+                                        <th class="col-md- auto font-weight-bold">Sr.No</th>
+                                        <th class="col-md- auto font-weight-bold">P.P. No</th>
+                                        <th class="col-md- auto font-weight-bold">Name</th>
+                                        <th class="col-md- auto font-weight-bold">Loan Case</th>
+                                        <th class="col-md- auto font-weight-bold">LC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Account No.</th>
+                                        <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Remarks</th>
+                                        <th class="col-md- auto text-center font-weight-bold"><center><button type="button" onclick="openResponsiblePPs();" class="rounded-circle btn btn-danger btn-sm"><i class="fa fa-plus text-white"></i></button></center></th>
+                                    </tr>
+                                </thead>
+                                <tbody></tbody>
+                            </table>
+                        </div>
+                    </div>
+                    
+                    <div id="referenceSection" class="mt-3 p-3 border border-danger mb-3">
+                        <h6>References</h6>
+                        <ul id="refList" class="list-group mb-3"></ul>
+                        <button type="button" class="btn btn-success mb-3" id="saveBtn">Save</button>
+                        <div id="searchSection">
+                            <select id="refType" class="form-select mb-2">
+                                <option value="0" selected>Please select reference</option>
+                                <option value="Manual">Manual</option>
+                                <option value="Policy">Policy</option>
+                                <option value="Circular">Circular</option>
+                            </select>
+                            <div id="searchInputs" style="display:none;">
+                                <input id="keyword" class="form-control mb-2" placeholder="keyword" />
+                                <button type="button" class="btn btn-primary" id="searchBtn">Search</button>
+                            </div>
+                            <div id="manualInputs" style="display:none;">
+                                <input id="manualName" class="form-control mb-2" placeholder="Manual/Policy Name" />
+                                <input id="chapterSection" class="form-control mb-2" placeholder="Chapter No + Section" />
+                                <button type="button" class="btn btn-primary" id="addManualBtn">Add</button>
+                            </div>
+                        </div>
+                        <table class="table" id="resultTbl" style="display:none;">
+                            <thead>
+                                <tr>
+                                    <th>TITLE</th>
+                                    <th>REFERENCE ID</th>
+                                    <th>INSTRUCTIONS DETAILS</th>
+                                    <th>KEYWORDS</th>
+                                    <th>View Circular</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-warning" id="confirmUpdateBtn" onclick="confirmDetailUpdates();">Confirm Updates</button>
+                <div id="actionButtons" class="d-none">
+                    <button id="btnUpdatePara" type="button" class="btn btn-danger" onclick="finalUpdateMemoContent(g_obsId);">Update Audit Para</button>
+                    <button id="btnDropPara" type="button" class="btn btn-danger" onclick="dropObservation(g_obsId,7,g_selectedRiskId);">Drop Audit Para</button>
+                    <button id="btnSubmitAuditee" type="button" class="btn btn-danger" onclick="submitObservationToAuditee(g_obsId,2,g_selectedRiskId);">Submit to Auditee</button>
+                    <button id="btnAddDraft" type="button" class="btn btn-danger" onclick="addToDraft();">Add to Draft</button>
+                    <button id="btnSettled" type="button" class="btn btn-danger" onclick="settleObservation();">Settled</button>
+                </div>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    
+
+<div id="ResponsiblePPModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-lg" style="min-width:95% !important" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title">Responsible Person</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group">
+
+                        <label class="form-control text-bold fw-bold text-center">Search Responsible By LC Number</label>
+
+                        <div class="row col-sm-12">
+                            <div class="col-sm-5">
+                                <label for="viewMemo_memo">Loan Case No.</label>
+                                <input type="text" class="form-control" id="responsibleLCNoEntryField" />
+                            </div>
+                            <div class="col-sm-5">
+                                <label for="viewMemo_memo">Branch Code</label>
+                                <input type="text" class="form-control" id="responsibleBrCodeEntryField" />
+                            </div>
+                            <div class="col-sm-2 d-flex align-items-end">
+                                <button onclick="respSectionUpdate.getLCDetails();" type="button" class="btn btn-danger w-100">Find</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div id="matchedPPNoPanels" style="padding:20px;">
+                        </div>
+                    </div>
+                    <div class="form-group">
+
+                        <label class="form-control text-bold fw-bold text-center">Search Responsible By PP No.</label>
+
+                        <div id="findBYPPNOPanel" class="mt-2 row col-md-12">
+                            <div class="col-md-2">
+                                <input id="responsiblePPNoEntryField" class="form-control" type="text" placeholder="Enter PP. No." />
+                            </div>
+                            <div class="col-md-2">
+                                <input id="responsibleAccountNumberEntryField" class="form-control" type="number" placeholder="Enter Account Number" />
+                            </div>
+                            <div class="col-md-2">
+                                <input id="responsibleAccountAmountEntryField" class="form-control" type="number" placeholder="Enter Account Amount" />
+                            </div>
+                            <div class="col-md-2">
+                                <input id="loanCaseNumber" class="form-control" type="text" placeholder="Enter LC No." />
+                            </div>
+                            <div class="col-md-2">
+                                <input id="loanCaseAmount" class="form-control" type="text" placeholder="Enter LC Amount" />
+                            </div>
+
+                            <button type="button" onclick="respSectionUpdate.getMatchedPP();" class="col-md-2 btn btn-success">Search</button>
+
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div id="matchedPPNoPanelsBYPP" style="padding:20px;">
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button id="addResponsibleButton" onclick="addResponsibilityToMainTable('A');" type="button" class="btn btn-danger">Add Responsibility</button>
+                <button id="updateResponsibleButton" onclick="addResponsibilityToMainTable('U');" type="button" class="btn btn-success d-none">Update Responsibility</button>
+                <button id="deleteResponsibleButton" onclick="addResponsibilityToMainTable('D');" type="button" class="btn btn-danger d-none">Delete Responsibility</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="DSAModel" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-xl" style="width:95% !important;" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title">Creation of DSA</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form>
+
+                    <div class="form-group">
+                        <label for="viewMemo_memo">DSA Heading</label>
+
+                        <textarea id="dsaHeading" readonly="readonly" class="form-control">
+
+                          </textarea>
+
+                    </div>
+                    <div class="form-group">
+                        <label for="viewMemo_memo">DSA Content</label>
+                        <div id="dsaContent" disabled="disabled" style="height: auto; overflow-y: auto;" class="form-control"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <center style="padding-top:10px; height:40px;" class="bg-danger text-light"><h6>Assigment of DSA to responsibles </h6></center>
+                        <div class="w-100">
+                            <table id="dsaResponsibles" class="table table-hover table-bordered table-hover mt-3 table-striped">
+                                <thead style="background-color: #19875478 !important; ">
+                                    <tr>
+                                        <th class="col-md- auto font-weight-bold">Sr.No</th>
+                                        <th class="col-md- auto font-weight-bold">P.P. No</th>
+                                        <th class="col-md- auto font-weight-bold">Name</th>
+                                        <th class="col-md- auto font-weight-bold">Loan Case</th>
+                                        <th class="col-md- auto font-weight-bold">LC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">Account No.</th>
+                                        <th class="col-md- auto font-weight-bold">ACC Amount</th>
+                                        <th class="col-md- auto font-weight-bold">DSA Issue to</th>
+
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button onclick="submitObservationToAuditeeAfterDSAIssuance();" type="button" class="btn btn-danger">Issue DSA to selected Responsibles</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/AIS/AIS/wwwroot/js/referenceSection.js
+++ b/AIS/AIS/wwwroot/js/referenceSection.js
@@ -136,6 +136,7 @@ function initReferenceSection(comId, readOnly, containerSelector) {
             data: JSON.stringify(payload),
             success: function (msg) {
                 alert(msg);
+                container.trigger('referenceSectionSaved');
                 // refresh current model instead of entire view
                 initReferenceSection(comId, readOnly, containerSelector);
             }


### PR DESCRIPTION
## Summary
- Create Manage Observation Field page under Execution with entity dropdown, observation table and memo update modal.
- Enforce reference section save and confirmation before enabling status-based actions like submit to auditee, add to draft or settle.
- Trigger event on reference save to allow UI validation and add controller action to serve the new view.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e33c41aa8832ebc9751a228cb8f2a