### PR TITLE
Fix responsibility handling and para loading in audit views

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -44,10 +44,9 @@
             tableSelector: '#viewMemo_respPP_ObSent',
             changesTableSelector: '#c_viewMemo_respPP_ObSent',
             modalSelector: '#ResponsiblePPModel',
-            status: 4,
+            status: 1,
             directSaveMode: false,
             afterSave: function () {
-                respSection.reload();
                 viewObservationDetails(g_obsId, g_statusId);
             }
         });
@@ -202,6 +201,9 @@
     function viewObservationDetails(obsId,status_id){
         g_obsId=obsId;
         g_statusId = status_id;
+        g_procId = 0;
+        g_subProcId = 0;
+        g_procDetailId = 0;
         $('#viewMemoDetailsModel').modal('show');
 
 
@@ -255,9 +257,9 @@
          $('#viewMemo_process_ObSent').val(data.procesS_ID);
          $('#viewMemo_amount_ObSent').val(data.amounT_INVOLVED);
          $('#viewMemo_inst_ObSent').val(data.nO_OF_INSTANCES);
-         g_procId=data.procesS_ID;
-         g_subProcId=data.subchecklisT_ID;
-         g_procDetailId=data.checklistdetaiL_ID;
+         g_procId = data.procesS_ID;
+         g_subProcId = data.subchecklisT_ID;
+         g_procDetailId = data.checklistdetaiL_ID || 0;
          getSubCheckListOfProcess();
         respSection.updateContext({
             newParaId: data.neW_PARA_ID,
@@ -315,7 +317,7 @@
                     $('#viewMemo_checklist_ObSent').append('<option value="' + v.s_ID + '">' + v.heading + '</option>');
                 });
                 if(g_procDetailId !=0)
-                    $('#viewMemo_checklist_ObSent').val(g_procDetailId);
+                    $('#viewMemo_checklist_ObSent').val(g_procDetailId).trigger('change');
 
                 },
                 dataType: "json",

--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -27,10 +27,9 @@
             tableSelector: '#viewMemo_respPP_ObSent',
             changesTableSelector: '#c_viewMemo_respPP_ObSent',
             modalSelector: '#ResponsiblePPModel',
-            status: 7,
+            status: 1,
             directSaveMode: false,
             afterSave: function () {
-                respSection.reload();
                 viewObservationDetails(g_obsId, $('#checklistDetailsPanel tbody tr#obs_' + g_obsId + ' .preconcludingStatusField').text());
             }
         });
@@ -92,6 +91,9 @@
 
       function viewObservationDetails(obsId, status){
           g_obsId=obsId;
+          g_procId = 0;
+          g_subProcId = 0;
+          g_procDetailId = 0;
           $('#viewMemoDetailsModel').modal('show');
 
           if(status=="Pending"){
@@ -137,16 +139,16 @@
            g_selectedRiskId = data.riskmodeL_ID;
            updateRiskDisplay();
            $('#viewMemo_process_ObSent').val(data.procesS_ID);
-           $('#viewMemo_paraNo_ObSent').val(data.finaL_PARA_NO);
+           $('#viewMemo_paraNo_ObSent').val(data.finaL_PARA_NO || data.drafT_PARA_NO || data.parA_NO);
            $('#viewMemo_amount_ObSent').val(data.amounT_INVOLVED);
            $('#viewMemo_inst_ObSent').val(data.nO_OF_INSTANCES);
 
            $('#gistPara_response_ObSent').val(data.qA_GIST);
            $('#audRecommend_response_ObSent').val(data.qA_RECOM);
 
-           g_procId=data.procesS_ID;
-           g_subProcId=data.subchecklisT_ID;
-           g_procDetailId=data.checklistdetaiL_ID;
+           g_procId = data.procesS_ID;
+           g_subProcId = data.subchecklisT_ID;
+           g_procDetailId = data.checklistdetaiL_ID || 0;
            getSubCheckListOfProcess();
         respSection.updateContext({
             newParaId: data.neW_PARA_ID,
@@ -204,7 +206,7 @@
                       $('#viewMemo_checklist_ObSent').append('<option value="' + v.s_ID + '">' + v.heading + '</option>');
                   });
                   if(g_procDetailId !=0)
-                      $('#viewMemo_checklist_ObSent').val(g_procDetailId);
+                      $('#viewMemo_checklist_ObSent').val(g_procDetailId).trigger('change');
 
                   },
                   dataType: "json",


### PR DESCRIPTION
## Summary
- Align responsibility section with branch management behavior so responsibles can be added/edited/deleted
- Reset process context to properly load selected checklist detail in draft report modal
- Show correct para number and reload responsibility table in pre-concluding audit view

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e880484a8832ea9c7d452445d85e6