### PR TITLE
Fix g_procDetailId not loading in draft report view

### DIFF
--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -318,7 +318,7 @@
                     $('#viewMemo_checklist_ObSent').append('<option value="' + v.s_ID + '">' + v.heading + '</option>');
                 });
                 if (g_procDetailId != 0)
-                    $('#viewMemo_checklist_ObSent').val(g_procDetailId).trigger('change');
+                    $('#viewMemo_checklist_ObSent').val(g_procDetailId);
 
                 },
                 dataType: "json",


### PR DESCRIPTION
## Summary
- ensure checklist detail selection is retained by removing unnecessary change trigger

## Testing
- `dotnet build AIS.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ef4a59604832ea898160a49a82bbf