### PR TITLE
Ensure responsibility section loads correctly in pre-concluding audit

### DIFF
--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -149,10 +149,10 @@
            g_procDetailId=data.checklistdetaiL_ID;
            getSubCheckListOfProcess();
         respSection.updateContext({
-            newParaId: data.neW_PARA_ID,
-            oldParaId: data.olD_PARA_ID,
-            indicator: data.indicator,
-            comId: data.coM_ID,
+            newParaId: data.neW_PARA_ID || g_obsId,
+            oldParaId: data.olD_PARA_ID || 0,
+            indicator: data.indicator || '',
+            comId: data.coM_ID || 0,
             readOnly: false
         });
                  initReferenceSection(g_obsId, false, '#viewMemoDetailsModel #referenceSection');
@@ -695,7 +695,7 @@
     </div>
 </div>
 <div id="ResponsiblePPModel" class="modal" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-dialog modal-lg" style="min-width:95% !important" role="document">
         <div class="modal-content">
             <div class="modal-header bg-success text-white">
                 <h5 class="modal-title">Responsible Person</h5>
@@ -704,18 +704,55 @@
             <div class="modal-body">
                 <form>
                     <div class="form-group">
-                        <label for="responsiblePPNoEntryField">P.P No.</label>
+
+                        <label class="form-control text-bold fw-bold text-center">Search Responsible By LC Number</label>
+
                         <div class="row col-sm-12">
-                            <div class="col-sm-10">
-                                <input type="text" class="form-control" id="responsiblePPNoEntryField" />
+                            <div class="col-sm-5">
+                                <label for="viewMemo_memo">Loan Case No.</label>
+                                <input type="text" class="form-control" id="responsibleLCNoEntryField" />
                             </div>
-                            <div class="col-sm-2 w-100">
-                                <button type="button" onclick="respSection.getMatchedPP();" class="btn btn-danger">Find</button>
+                            <div class="col-sm-5">
+                                <label for="viewMemo_memo">Branch Code</label>
+                                <input type="text" class="form-control" id="responsibleBrCodeEntryField" />
+                            </div>
+                            <div class="col-sm-2 d-flex align-items-end">
+                                <button onclick="respSection.getLCDetails();" type="button" class="btn btn-danger w-100">Find</button>
                             </div>
                         </div>
                     </div>
                     <div class="form-group">
-                        <div id="matchedPPNoPanels" style="padding:20px;"></div>
+                        <div id="matchedPPNoPanels" style="padding:20px;">
+                        </div>
+                    </div>
+                    <div class="form-group">
+
+                        <label class="form-control text-bold fw-bold text-center">Search Responsible By PP No.</label>
+
+                        <div id="findBYPPNOPanel" class="mt-2 row col-md-12">
+                            <div class="col-md-2">
+                                <input id="responsiblePPNoEntryField" class="form-control" type="text" placeholder="Enter PP. No." />
+                            </div>
+                            <div class="col-md-2">
+                                <input id="responsibleAccountNumberEntryField" class="form-control" type="number" placeholder="Enter Account Number" />
+                            </div>
+                            <div class="col-md-2">
+                                <input id="responsibleAccountAmountEntryField" class="form-control" type="number" placeholder="Enter Account Amount" />
+                            </div>
+                            <div class="col-md-2">
+                                <input id="loanCaseNumber" class="form-control" type="text" placeholder="Enter LC No." />
+                            </div>
+                            <div class="col-md-2">
+                                <input id="loanCaseAmount" class="form-control" type="text" placeholder="Enter LC Amount" />
+                            </div>
+
+                            <button type="button" onclick="respSection.getMatchedPP();" class="col-md-2 btn btn-success">Search</button>
+
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div id="matchedPPNoPanelsBYPP" style="padding:20px;">
+                        </div>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## Summary
- align responsibility context values in pre-concluding audit view with draft report behavior
- expand Responsible Person modal to support searches by LC and PP similar to draft view

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f093c4d18832e889e36ae709174ce