### PR TITLE
Use instruction date for reference search

### DIFF
--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -356,9 +356,7 @@ namespace AIS.Controllers
                             {
                             ComId = rdr["COM_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["COM_ID"]),
                             EntId = rdr["ENT_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["ENT_ID"]),
-                            ParaTitle = rdr["PARA_TITLE"].ToString(),
-                            ReferenceId = rdr["REFERENCE_ID"] == DBNull.Value ? null : (int?)Convert.ToInt32(rdr["REFERENCE_ID"]),
-                            ReferenceType = rdr["REFERENCE_TYPE"].ToString(),
+                            ParaTitle = rdr["PARA_TITLE"].ToString(),                            ReferenceType = rdr["REFERENCE_TYPE"].ToString(),
                             AssignedAuditorId = rdr["ASSIGNED_AUDITOR"] == DBNull.Value ? null : (int?)Convert.ToInt32(rdr["ASSIGNED_AUDITOR"]),
                             Status = rdr["STATUS"].ToString()
                             });
@@ -449,9 +447,8 @@ namespace AIS.Controllers
                         {
                         list.Add(new ReferenceSearchResultModel
                             {
-                            ReferenceId = rdr["REFERENCE_ID"] == DBNull.Value ? 0 : Convert.ToInt32(rdr["REFERENCE_ID"]),
                             Title = rdr["TITLE"] == DBNull.Value ? "" : rdr["TITLE"].ToString(),
-                            INSTRUCTIONSDATE = rdr["INSTRUCTIONSDATE"].ToString(),
+                            INSTRUCTIONSDATE = rdr["INSTRUCTIONSDATE"] == DBNull.Value ? "" : rdr["INSTRUCTIONSDATE"].ToString(),
                             ReferenceType = rdr["REFERENCE_TYPE"] == DBNull.Value ? "" : rdr["REFERENCE_TYPE"].ToString(),
                             INSTRUCTIONSDETAILS = rdr["INSTRUCTIONSDETAILS"] == DBNull.Value ? "" : rdr["INSTRUCTIONSDETAILS"].ToString(),
                             KEYWORDS = rdr["KEYWORDS"] == DBNull.Value ? "" : rdr["KEYWORDS"].ToString(),

--- a/AIS/AIS/Models/ReferenceSearchResultModel.cs
+++ b/AIS/AIS/Models/ReferenceSearchResultModel.cs
@@ -2,7 +2,6 @@ namespace AIS.Models
 {
     public class ReferenceSearchResultModel
     {
-        public int ReferenceId { get; set; }
         public string Title { get; set; }
         public string INSTRUCTIONSDETAILS { get; set; }
         public string INSTRUCTIONSDATE { get; set; }

--- a/AIS/AIS/Views/AuditeePortal/observation_assigned.cshtml
+++ b/AIS/AIS/Views/AuditeePortal/observation_assigned.cshtml
@@ -513,7 +513,7 @@
                             <thead>
                                 <tr>
                                     <th>TITLE</th>
-                                    <th>REFERENCE ID</th>
+                                    <th>Circular Date</th>
                                     <th>INSTRUCTIONS DETAILS</th>
                                     <th>KEYWORDS</th>
                                     <th>View Circular</th>

--- a/AIS/AIS/Views/Execution/Manage_obervation_field.cshtml
+++ b/AIS/AIS/Views/Execution/Manage_obervation_field.cshtml
@@ -659,7 +659,7 @@
                             <thead>
                                 <tr>
                                     <th>TITLE</th>
-                                    <th>REFERENCE ID</th>
+                                    <th>Circular Date</th>
                                     <th>INSTRUCTIONS DETAILS</th>
                                     <th>KEYWORDS</th>
                                     <th>View Circular</th>
@@ -838,7 +838,7 @@
                             <thead>
                                 <tr>
                                     <th>TITLE</th>
-                                    <th>REFERENCE ID</th>
+                                    <th>Circular Date</th>
                                     <th>INSTRUCTIONS DETAILS</th>
                                     <th>KEYWORDS</th>
                                     <th>View Circular</th>

--- a/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
+++ b/AIS/AIS/Views/Execution/draft_audit_report_branch.cshtml
@@ -752,7 +752,7 @@
                             <thead>
                                 <tr>
                                     <th>TITLE</th>
-                                    <th>REFERENCE ID</th>
+                                    <th>Circular Date</th>
                                     <th>INSTRUCTIONS DETAILS</th>
                                     <th>KEYWORDS</th>
                                     <th>View Circular</th>

--- a/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras.cshtml
@@ -492,7 +492,7 @@ function updateObservationStatus() {
                             <thead>
                                 <tr>
                                     <th>TITLE</th>
-                                    <th>REFERENCE ID</th>
+                                    <th>Circular Date</th>
                                     <th>INSTRUCTIONS DETAILS</th>
                                     <th>KEYWORDS</th>
                                     <th>View Circular</th>

--- a/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
+++ b/AIS/AIS/Views/Execution/manage_audit_paras_authorized.cshtml
@@ -519,7 +519,7 @@ function updateObservationStatus(type) {
                                     <thead>
                                         <tr>
                                             <th>TITLE</th>
-                                            <th>REFERENCE ID</th>
+                                            <th>Circular Date</th>
                                             <th>INSTRUCTIONS DETAILS</th>
                                             <th>KEYWORDS</th>
                                             <th>View Circular</th>

--- a/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
+++ b/AIS/AIS/Views/Execution/manage_draft_report_paras_branch.cshtml
@@ -435,7 +435,7 @@
                             <thead>
                                 <tr>
                                     <th>TITLE</th>
-                                    <th>REFERENCE ID</th>
+                                    <th>Circular Date</th>
                                     <th>INSTRUCTIONS DETAILS</th>
                                     <th>KEYWORDS</th>
                                     <th>View Circular</th>

--- a/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
+++ b/AIS/AIS/Views/Execution/manage_observations_branches.cshtml
@@ -706,7 +706,7 @@
                             <thead>
                                 <tr>
                                     <th>TITLE</th>
-                                    <th>REFERENCE ID</th>
+                                    <th>Circular Date</th>
                                     <th>INSTRUCTIONS DETAILS</th>
                                     <th>KEYWORDS</th>
                                     <th>View Circular</th>

--- a/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
+++ b/AIS/AIS/Views/Execution/pre_concluding_audit.cshtml
@@ -613,7 +613,7 @@
                             <thead>
                                 <tr>
                                     <th>TITLE</th>
-                                    <th>REFERENCE ID</th>
+                                    <th>Circular Date</th>
                                     <th>INSTRUCTIONS DETAILS</th>
                                     <th>KEYWORDS</th>
                                     <th>View Circular</th>

--- a/AIS/AIS/Views/FAD/ReferenceDisplay.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceDisplay.cshtml
@@ -30,7 +30,7 @@
         <thead>
             <tr>
                 <th>TITLE</th>
-                <th>REFERENCE ID</th>
+                <th>Circular Date</th>
                 <th>INSTRUCTIONS DETAILS</th>
                 <th>KEYWORDS</th>
                 <th>View Circular</th>

--- a/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
+++ b/AIS/AIS/Views/FAD/ReferenceUpdateEdit.cshtml
@@ -29,7 +29,7 @@
     <thead>
         <tr>
             <th>TITLE</th>
-            <th>REFERENCE ID</th>
+            <th>Circular Date</th>
             <th>INSTRUCTIONS DETAILS</th>
             <th>KEYWORDS</th>
             <th>View Circular</th>
@@ -61,11 +61,11 @@
                 $.each(d,function(i,it){
                     body.append('<tr>'+
                         '<td>'+it.title+'</td>'+
-                        '<td>'+it.referenceId+'</td>'+
+                        '<td>'+it.instructionsDate+'</td>'+
                         '<td>'+it.instructionsdetails+'</td>'+
                         '<td>'+it.keywords+'</td>'+
                         '<td><button class="view btn btn-sm btn-secondary" data-url="'+it.referenceurl+'">View</button></td>'+
-                        '<td><button type="button" class="attach btn btn-sm btn-primary" data-id="'+it.referenceId+'">Attach</button></td>'+
+                        '<td><button type="button" class="attach btn btn-sm btn-primary" data-id="'+it.instructionsDate+'">Attach</button></td>'+
                         '</tr>');
                 });
             });
@@ -140,7 +140,7 @@
             $.each(refDetails, function(i,r){
                 var lnk = r.linkId !== undefined && r.linkId !== null ? r.linkId : null;
                 if(lnk === null){
-                    var found = refLinks.find(function(fl){ return fl.referenceId === r.id; });
+                    var found = refLinks.find(function(fl){ return fl.instructionsDate === r.instructionsDate; });
                     if(found) lnk = found.linkId;
                 }
                 payload.references.push({
@@ -149,7 +149,7 @@
                     oldParaId: 0,
                     newParaId: 0,
                     paraId: comId,
-                    referenceId: r.id,
+                    instructionsDate: r.instructionsDate,
                     referenceTitle: r.instructionsTitle,
                     creditManualId: null,
                     opManualId: null,

--- a/AIS/AIS/Views/FAD/ViewParaReferences.cshtml
+++ b/AIS/AIS/Views/FAD/ViewParaReferences.cshtml
@@ -25,7 +25,7 @@
         <thead>
             <tr>
                 <th>TITLE</th>
-                <th>REFERENCE ID</th>
+                <th>Circular Date</th>
                 <th>INSTRUCTIONS DETAILS</th>
                 <th>KEYWORDS</th>
                 <th>View Circular</th>

--- a/AIS/AIS/wwwroot/js/referenceSection.js
+++ b/AIS/AIS/wwwroot/js/referenceSection.js
@@ -46,7 +46,7 @@ function initReferenceSection(comId, readOnly, containerSelector) {
                     '<td>' + it.instructionsdetails + '</td>' +
                     '<td>' + it.keywords + '</td>' +
                     '<td><button type="button" class="view btn btn-sm btn-secondary" data-url="' + it.referenceurl + '">View</button></td>' +
-                    (readOnly ? '' : '<td><button type="button" class="attach btn btn-sm btn-primary" data-id="' + it.referenceId + '">Attach</button></td>') +
+                    (readOnly ? '' : '<td><button type="button" class="attach btn btn-sm btn-primary" data-id="' + it.instructionsDate + '">Attach</button></td>') +
                     '</tr>');
             });
         });
@@ -109,7 +109,7 @@ function initReferenceSection(comId, readOnly, containerSelector) {
         $.each(refDetails, function (i, r) {
             var lnk = r.linkId !== undefined && r.linkId !== null ? r.linkId : null;
             if (lnk === null) {
-                var found = refLinks.find(function (fl) { return fl.referenceId === r.id; });
+                var found = refLinks.find(function (fl) { return fl.instructionsDate === r.instructionsDate; });
                 if (found) lnk = found.linkId;
             }
             payload.references.push({
@@ -118,7 +118,7 @@ function initReferenceSection(comId, readOnly, containerSelector) {
                 oldParaId: 0,
                 newParaId: 0,
                 paraId: comId,
-                referenceId: r.id,
+                instructionsDate: r.instructionsDate,
                 referenceTitle: r.instructionsTitle,
                 creditManualId: null,
                 opManualId: null,


### PR DESCRIPTION
## Summary
- show circular issuance dates instead of numeric reference IDs
- carry instruction dates through reference selection and persistence

## Testing
- `dotnet build AIS/AIS.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f67e2d9b0832e94a93732bef29ac1