### PR TITLE
Display only date for reference instructions

### DIFF
--- a/AIS/AIS/wwwroot/js/referenceSection.js
+++ b/AIS/AIS/wwwroot/js/referenceSection.js
@@ -40,9 +40,10 @@ function initReferenceSection(comId, readOnly, containerSelector) {
         $.post(g_asiBaseURL + '/ApiCalls/SearchReferences', { referenceType: refType.val(), keyword: keywordInput.val() }, function (d) {
             var body = resultTbl.find('tbody'); body.empty();
             $.each(d, function (i, it) {
+                var dateTxt = it.instructionsDate ? it.instructionsDate.split('T')[0] : '';
                 body.append('<tr>' +
                     '<td>' + it.title + '</td>' +
-                    '<td>' + it.instructionsDate + '</td>' +
+                    '<td>' + dateTxt + '</td>' +
                     '<td>' + it.instructionsdetails + '</td>' +
                     '<td>' + it.keywords + '</td>' +
                     '<td><button type="button" class="view btn btn-sm btn-secondary" data-url="' + it.referenceurl + '">View</button></td>' +


### PR DESCRIPTION
## Summary
- ensure instruction dates in reference search results show only the date without timestamps

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688f6e229e4c832eb7ead0210b287478