### PR TITLE
Fix instructions date mapping and display

### DIFF
--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -448,7 +448,7 @@ namespace AIS.Controllers
                         list.Add(new ReferenceSearchResultModel
                             {
                             Title = rdr["TITLE"] == DBNull.Value ? "" : rdr["TITLE"].ToString(),
-                            INSTRUCTIONSDATE = rdr["INSTRUCTIONSDATE"] == DBNull.Value ? "" : rdr["INSTRUCTIONSDATE"].ToString(),
+                            InstructionsDate = rdr["INSTRUCTIONSDATE"] == DBNull.Value ? (DateTime?)null : Convert.ToDateTime(rdr["INSTRUCTIONSDATE"]),
                             ReferenceType = rdr["REFERENCE_TYPE"] == DBNull.Value ? "" : rdr["REFERENCE_TYPE"].ToString(),
                             INSTRUCTIONSDETAILS = rdr["INSTRUCTIONSDETAILS"] == DBNull.Value ? "" : rdr["INSTRUCTIONSDETAILS"].ToString(),
                             KEYWORDS = rdr["KEYWORDS"] == DBNull.Value ? "" : rdr["KEYWORDS"].ToString(),

--- a/AIS/AIS/Models/ReferenceSearchResultModel.cs
+++ b/AIS/AIS/Models/ReferenceSearchResultModel.cs
@@ -1,10 +1,12 @@
+using System;
+
 namespace AIS.Models
 {
     public class ReferenceSearchResultModel
     {
         public string Title { get; set; }
         public string INSTRUCTIONSDETAILS { get; set; }
-        public string INSTRUCTIONSDATE { get; set; }
+        public DateTime? InstructionsDate { get; set; }
         public string KEYWORDS { get; set; }
         public string REFERENCEURL { get; set; }
         public string ReferenceType { get; set; }

--- a/AIS/AIS/wwwroot/js/referenceSection.js
+++ b/AIS/AIS/wwwroot/js/referenceSection.js
@@ -47,7 +47,7 @@ function initReferenceSection(comId, readOnly, containerSelector) {
         $.post(g_asiBaseURL + '/ApiCalls/SearchReferences', { referenceType: refType.val(), keyword: keywordInput.val() }, function (d) {
             var body = resultTbl.find('tbody'); body.empty();
             $.each(d, function (i, it) {
-                var dateTxt = formatDate(it.instructionsdate);
+                var dateTxt = formatDate(it.instructionsDate);
                 body.append('<tr>' +
                     '<td>' + it.title + '</td>' +
                     '<td>' + dateTxt + '</td>' +


### PR DESCRIPTION
## Summary
- use nullable DateTime for reference search result instructions date
- map INSTRUCTIONSDATE to DateTime in FAD DB connection
- display instructions date correctly in referenceSection.js

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688f79c5ae70832ea30c45f932216afe