### PR TITLE
Fix public holiday entry serialization

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -3299,7 +3299,7 @@ namespace AIS.Controllers
             }
 
         [HttpPost]
-        public PublicHolidayModel add_public_holiday(PublicHolidayModel model)
+        public PublicHolidayModel add_public_holiday([FromBody] PublicHolidayModel model)
             {
             return dBConnection.AddPublicHoliday(model);
             }

--- a/AIS/AIS/Views/AdministrationPanel/ManagePublicHolidays.cshtml
+++ b/AIS/AIS/Views/AdministrationPanel/ManagePublicHolidays.cshtml
@@ -52,9 +52,9 @@
                 var rows = '';
                 data.forEach(function (item) {
                     rows += `<tr>
-                        <td>${item.holidaY_DATE.substring(0,10)}</td>
+                        <td>${item.hOLIDAY_DATE.substring(0,10)}</td>
                         <td>${item.iS_HOLIDAY === "Y" ? "Holiday" : item.iS_WEEKEND === "Y" ? "Weekend" : ""}</td>
-                        <td>${item.holidaY_NAME || ''}</td>
+                        <td>${item.hOLIDAY_NAME || ''}</td>
                     </tr>`;
                 });
                 $('#holidaysTable tbody').html(rows);
@@ -72,7 +72,7 @@
             var name = $('#holidayName').val();
 
             var model = {
-                HOLIDAY_DATE: date,
+                HOLIDAY_DATE: new Date(date),
                 HOLIDAY_YEAR: new Date(date).getFullYear(),
                 IS_WEEKEND: type === 'Weekend' ? 'Y' : 'N',
                 IS_HOLIDAY: type === 'Holiday' ? 'Y' : 'N',


### PR DESCRIPTION
## Summary
- ensure JSON body is bound when adding public holidays
- correct Manage Public Holidays view to map server field names and send proper date

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e12f0478832eab3c008a2a9e1b44