### PR TITLE
Fix AddVersionHistory fetch route

### DIFF
--- a/AIS/AIS/Views/AdministrationPanel/ManageVersionHistory.cshtml
+++ b/AIS/AIS/Views/AdministrationPanel/ManageVersionHistory.cshtml
@@ -224,9 +224,11 @@
             addForm.addEventListener('submit', async function (e) {
                 e.preventDefault();
                 var formData = new FormData(addForm);
-                var response = await fetch('/AddVersionHistory', {
+                var url = '@Url.Action("AddVersionHistory", "ApiCalls")';
+                var response = await fetch(url, {
                     method: 'POST',
-                    body: formData
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(Object.fromEntries(formData.entries()))
                 });
                 if (response.ok) {
                     location.reload();


### PR DESCRIPTION
## Summary
- point Version History modal to correct AddVersionHistory endpoint
- send JSON from Add Version form so API model binding works

## Testing
- `dotnet test AIS/AIS.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6890e4e3c7f0832e9e45f4dffe932a21