### PR TITLE
Handle more document types in sampling viewers

### DIFF
--- a/AIS/AIS/Views/Sampling/account_document.cshtml
+++ b/AIS/AIS/Views/Sampling/account_document.cshtml
@@ -62,6 +62,13 @@
         initializeDataTable('account_document_list');
     }
     function viewDocument(docImage) {
+        if (!docImage) {
+            alert("No document data received.");
+            return;
+        }
+
+        docImage = docImage.trim();
+
         let win = window.open("", "_blank");
         if (!win) {
             console.error("Popup blocked");
@@ -69,9 +76,26 @@
             return;
         }
 
+        let mime = '';
+        if (docImage.startsWith('JVBERi0xL')) {
+            mime = 'application/pdf';
+        } else if (docImage.startsWith('iVBOR')) {
+            mime = 'image/png';
+        } else if (docImage.startsWith('/9j/')) {
+            mime = 'image/jpeg';
+        } else if (docImage.startsWith('R0lGOD')) {
+            mime = 'image/gif';
+        } else if (docImage.startsWith('Qk')) {
+            mime = 'image/bmp';
+        } else if (docImage.startsWith('SUkq')) {
+            mime = 'image/tiff';
+        }
 
-        if (docImage.startsWith("/9j/")) {
-            let imageSrc = "data:image/jpeg;base64," + docImage;
+        if (mime === 'application/pdf') {
+            let pdfSrc = `data:${mime};base64,` + docImage;
+            win.location.href = pdfSrc;
+        } else if (mime.startsWith('image/')) {
+            let imageSrc = `data:${mime};base64,` + docImage;
             win.document.write(`
                 <html>
                 <head><title>Document Viewer</title></head>
@@ -80,16 +104,7 @@
                 <\/body>
                 </html>
             `);
-        }
-
-        else if (docImage.startsWith("JVBERi0xL")) {
-            let pdfSrc = "data:application/pdf;base64," + docImage;
-
-
-            win.location.href = pdfSrc;
-        }
-
-        else {
+        } else {
             console.error("Unsupported document type");
             alert("The document type is not supported.");
             win.close();

--- a/AIS/AIS/Views/Sampling/loan_documents.cshtml
+++ b/AIS/AIS/Views/Sampling/loan_documents.cshtml
@@ -68,8 +68,8 @@
         initializeDataTable('loan_document_list');
     }
 
-      function viewDocument(docId) {
-        if (!docId) {  // Fix: Check for null/undefined values
+    function viewDocument(docId, docName) {
+        if (!docId) {
             alert("Document ID is missing.");
             return;
         }
@@ -88,23 +88,42 @@
                     return;
                 }
 
-                docImage = docImage.trim(); // Remove extra spaces or newlines
+                docImage = docImage.trim();
+
                 let win = window.open("", "_blank");
                 if (!win) {
                     alert("Please allow popups to view the document.");
                     return;
                 }
 
-                if (docImage.startsWith("/9j/")) {  // JPEG image
-                    let imageSrc = "data:image/jpeg;base64," + docImage;
-                    win.document.write(`<html><body style="margin:0;"><img src="${imageSrc}" style="width:100%; height:auto;"/><\/body></html>`);
-                    win.document.close();
+                let extension = '';
+                if (docName && docName.indexOf('.') > -1) {
+                    extension = docName.split('.').pop().toLowerCase();
+                }
 
-                } else if (docImage.startsWith("JVBERi0xL")) {  // PDF document
-                    let pdfSrc = "data:application/pdf;base64," + docImage;
+                let mime = '';
+                if (extension === 'pdf' || docImage.startsWith('JVBERi0xL')) {
+                    mime = 'application/pdf';
+                } else if (extension === 'png' || docImage.startsWith('iVBOR')) {
+                    mime = 'image/png';
+                } else if (extension === 'gif' || docImage.startsWith('R0lGOD')) {
+                    mime = 'image/gif';
+                } else if (extension === 'bmp' || docImage.startsWith('Qk')) {
+                    mime = 'image/bmp';
+                } else if (extension === 'tiff' || extension === 'tif' || docImage.startsWith('SUkq')) {
+                    mime = 'image/tiff';
+                } else if (extension === 'jpeg' || extension === 'jpg' || docImage.startsWith('/9j/')) {
+                    mime = 'image/jpeg';
+                }
+
+                if (mime === 'application/pdf') {
+                    let pdfSrc = `data:${mime};base64,` + docImage;
                     win.document.write(`<html><body style="margin:0;"><embed src="${pdfSrc}" type="application/pdf" width="100%" height="100%"/><\/body></html>`);
                     win.document.close();
-
+                } else if (mime.startsWith('image/')) {
+                    let imageSrc = `data:${mime};base64,` + docImage;
+                    win.document.write(`<html><body style="margin:0;"><img src="${imageSrc}" style="width:100%; height:auto;"/><\/body></html>`);
+                    win.document.close();
                 } else {
                     console.error("Unsupported document type");
                     alert("The document type is not supported.");


### PR DESCRIPTION
## Summary
- Expand document viewer for loan samples to infer mime type from document name or base64, supporting PDF, PNG, GIF, BMP, TIFF, and JPEG
- Support the same set of formats for account documents

## Testing
- `dotnet build AIS.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository '... noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892c31a4010832e826113f4e252ae4e