### PR TITLE
Handle data URIs in account document viewer

### DIFF
--- a/AIS/AIS/Views/Sampling/account_document.cshtml
+++ b/AIS/AIS/Views/Sampling/account_document.cshtml
@@ -77,25 +77,35 @@
         }
 
         let mime = '';
-        if (docImage.startsWith('JVBERi0xL')) {
-            mime = 'application/pdf';
-        } else if (docImage.startsWith('iVBOR')) {
-            mime = 'image/png';
-        } else if (docImage.startsWith('/9j/')) {
-            mime = 'image/jpeg';
-        } else if (docImage.startsWith('R0lGOD')) {
-            mime = 'image/gif';
-        } else if (docImage.startsWith('Qk')) {
-            mime = 'image/bmp';
-        } else if (docImage.startsWith('SUkq')) {
-            mime = 'image/tiff';
+        let base64Data = docImage;
+
+        if (docImage.startsWith('data:')) {
+            var matches = docImage.match(/^data:(.*?);base64,(.*)$/);
+            if (matches) {
+                mime = matches[1];
+                base64Data = matches[2];
+            }
+        } else {
+            if (docImage.startsWith('JVBERi0')) {
+                mime = 'application/pdf';
+            } else if (docImage.startsWith('iVBOR')) {
+                mime = 'image/png';
+            } else if (docImage.startsWith('/9j/')) {
+                mime = 'image/jpeg';
+            } else if (docImage.startsWith('R0lGOD')) {
+                mime = 'image/gif';
+            } else if (docImage.startsWith('Qk')) {
+                mime = 'image/bmp';
+            } else if (docImage.startsWith('SUkq')) {
+                mime = 'image/tiff';
+            }
         }
 
         if (mime === 'application/pdf') {
-            let pdfSrc = `data:${mime};base64,` + docImage;
+            let pdfSrc = `data:${mime};base64,` + base64Data;
             win.location.href = pdfSrc;
         } else if (mime.startsWith('image/')) {
-            let imageSrc = `data:${mime};base64,` + docImage;
+            let imageSrc = `data:${mime};base64,` + base64Data;
             win.document.write(`
                 <html>
                 <head><title>Document Viewer</title></head>


### PR DESCRIPTION
## Summary
- handle `data:` URIs and detect base64 prefixes when opening account documents

## Testing
- `dotnet build AIS.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68938a824f08832e91b5ebc5672ed76c