### PR TITLE
Fix TinyMCE editor initialization and sizing in CAU observation

### DIFF
--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -15,16 +15,18 @@
     var g_respUser = [];
     var g_selectedRiskId = 0;
     var g_annexList = @Html.Raw(Json.Serialize(ViewData["AnnexList"]));
-    $('#document').ready(function () {
+    $(document).ready(function () {
         var url_string = window.location;
         var url = new URL(url_string);
         g_engId = url.searchParams.get("engId");
+        var editorHeight = $(window).height() / 2;
         tinymce.init({
             selector: '#template_box',
             plugins: 'advlist autolink lists link image charmap print preview anchor searchreplace visualblocks code fullscreen insertdatetime media table paste help wordcount',
             toolbar: 'undo redo | formatselect | bold italic underline forecolor backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | table | removeformat | code | fullscreen',
             menubar: 'file edit view insert format tools table help',
-            height: 400
+            width: '100%',
+            height: editorHeight
         });
 
         $('#updatedAnnexlist').select2();


### PR DESCRIPTION
## Summary
- Ensure TinyMCE initializes on document ready
- Set editor width to full page and height to half the viewport

## Testing
- `dotnet test AIS/AIS.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68967c120c70832ea5e7656aef147048