### PR TITLE
feat: add rich text editor to CAU observation gist

### DIFF
--- a/AIS/AIS/Views/Execution/cau_observation.cshtml
+++ b/AIS/AIS/Views/Execution/cau_observation.cshtml
@@ -31,6 +31,21 @@
         $('#auditPara_Annex').select2();
         $('#riskActivitiesSelectBox').select2();
 
+        if (typeof CKEDITOR !== 'undefined') {
+            CKEDITOR.replace('auditPara_Gist', {
+                extraPlugins: 'print',
+                toolbar: [
+                    { name: 'document', items: ['Source', '-', 'Print'] },
+                    { name: 'clipboard', items: ['Cut', 'Copy', 'Paste', 'Undo', 'Redo'] },
+                    { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'RemoveFormat'] },
+                    { name: 'paragraph', items: ['NumberedList', 'BulletedList', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock'] },
+                    { name: 'styles', items: ['Format', 'Font', 'FontSize'] },
+                    { name: 'colors', items: ['TextColor', 'BGColor'] },
+                    { name: 'insert', items: ['Table'] }
+                ]
+            });
+        }
+
         document.getElementById('amount_inv_field').addEventListener('input', function (e) {
             this.value = this.value.replace(/\D|^0(?=\d)/g, '');
         });
@@ -149,6 +164,9 @@
     function submitObservationToAuditee() {
         auditParaSection.updateRiskDisplay();
         var paraData = auditParaSection.getData();
+        if (CKEDITOR.instances['auditPara_Gist']) {
+            paraData.gist = CKEDITOR.instances['auditPara_Gist'].getData();
+        }
         if (paraData.annexureId == 0) {
             alert('Select Annexure');
             return;


### PR DESCRIPTION
## Summary
- enable CKEditor for audit para gist field in CAU observations
- capture gist content from editor when submitting observation

## Testing
- `dotnet build AIS.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68973809e340832eb42f36dd40b51085