### PR TITLE
Enable full CKEditor features and add rich text printing

### DIFF
--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -63,6 +63,13 @@
             videoEmbed: false,
             urls: false
         });
+
+        // add print option to rich text toolbar
+        var memoEditor = $('#viewMemo_memo').closest('.richText');
+        var memoToolbar = memoEditor.find('.richText-toolbar').first().find('ul');
+        var printBtn = $('<li><a href="#" id="memoPrintBtn" class="richText-btn" title="Print"><span class="fa fa-print"></span></a></li>');
+        memoToolbar.append(printBtn);
+        $('#memoPrintBtn').printPreview({ obj2print: '#' + memoEditor.find('.richText-editor').attr('id') });
             document.getElementById('viewMemo_amountInv').addEventListener('input', function (e) {
         this.value = this.value.replace(/\D|^0(?=\d)/g, ''); // Removes decimals and leading zeros
     });

--- a/AIS/AIS/Views/Execution/checklist_details.cshtml
+++ b/AIS/AIS/Views/Execution/checklist_details.cshtml
@@ -64,7 +64,10 @@
             urls: false
         });
 
-        // add print option to rich text toolbar
+        // Expose a print option within the rich text memo editor: the richText
+        // plugin does not include printing, so we append a button to its toolbar
+        // and wire it to printPreview targeting the memo's editor element. This
+        // allows users to trigger the browser's print dialog for memo content.
         var memoEditor = $('#viewMemo_memo').closest('.richText');
         var memoToolbar = memoEditor.find('.richText-toolbar').first().find('ul');
         var printBtn = $('<li><a href="#" id="memoPrintBtn" class="richText-btn" title="Print"><span class="fa fa-print"></span></a></li>');

--- a/AIS/AIS/wwwroot/js/fieldauditparaSection.js
+++ b/AIS/AIS/wwwroot/js/fieldauditparaSection.js
@@ -81,15 +81,19 @@ function initFieldAuditParaSection(config) {
         if (paraTextField.length && typeof CKEDITOR !== 'undefined') {
             paraTextEditor = CKEDITOR.replace(paraTextField.attr('id'), {
                 extraPlugins: 'print',
+                height: 500,
                 toolbar: [
-                    { name: 'document', items: ['Source', '-', 'Print'] },
-                    { name: 'clipboard', items: ['Cut', 'Copy', 'Paste', 'Undo', 'Redo'] },
-                    { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'RemoveFormat'] },
-                    { name: 'paragraph', items: ['NumberedList', 'BulletedList', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock'] },
+                    { name: 'document', items: ['Source', 'Preview', 'Print', 'PageBreak'] },
+                    { name: 'clipboard', items: ['Undo', 'Redo', 'Find', 'Replace', 'SelectAll', 'RemoveFormat'] },
                     { name: 'styles', items: ['Format', 'Font', 'FontSize'] },
+                    { name: 'basicstyles', items: ['Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', 'CopyFormatting'] },
                     { name: 'colors', items: ['TextColor', 'BGColor'] },
-                    { name: 'insert', items: ['Table'] }
-                ]
+                    { name: 'paragraph', items: ['NumberedList', 'BulletedList', 'Outdent', 'Indent', 'Blockquote', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock'] },
+                    { name: 'insert', items: ['Table', 'SpecialChar', 'HorizontalRule', 'Link', 'Unlink'] },
+                    { name: 'tools', items: ['Maximize'] }
+                ],
+                removePlugins: 'cloudservices,easyimage',
+                extraAllowedContent: true
             });
         }
     }

--- a/tests/checklist_details_print_button.test.js
+++ b/tests/checklist_details_print_button.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+// Simple regression test verifying that the checklist memo editor
+// includes a print button and invokes the print preview logic.
+// This is a static check since full UI automation is not available.
+
+const viewPath = path.join(__dirname, '..', 'AIS', 'AIS', 'Views', 'Execution', 'checklist_details.cshtml');
+const content = fs.readFileSync(viewPath, 'utf8');
+
+function assertContains(pattern, message) {
+  if (!pattern.test(content)) {
+    console.error(message);
+    process.exit(1);
+  }
+}
+
+// Check for memo print button markup
+assertContains(/id\s*=\s*"memoPrintBtn"/, 'memoPrintBtn not found in checklist_details.cshtml');
+assertContains(/fa\s+fa-print/, 'fa-print icon missing for print button');
+
+// Ensure printPreview plugin is invoked
+assertContains(/printPreview\(/, 'printPreview plugin not invoked for memo print button');
+
+console.log('Checklist memo print button markup and printPreview invocation verified.');


### PR DESCRIPTION
## Summary
- Expand CKEditor toolbar to expose full editing features in CAU observation text area
- Add print button to rich text memo editor for checklist details
- Add regression test validating presence of memo print button and print preview invocation

## Testing
- `node tests/checklist_details_print_button.test.js`
- `dotnet build AIS/AIS.sln` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689769265178832eb66d5ffe41cd8df5