### PR TITLE
Refactor FAD methods into correct partial

### DIFF
--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -1,3 +1,4 @@
+// Routes methods that call pkg_fad.* stored procedures.
 using AIS.Models;
 using Oracle.ManagedDataAccess.Client;
 using Oracle.ManagedDataAccess.Types;
@@ -10,6 +11,67 @@ namespace AIS.Controllers
     {
     public partial class DBConnection
         {
+        public List<RoleRespModel> GetRoleResponsibleForChecklistDetail()
+            {
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            var con = this.DatabaseConnection(); con.Open();
+            List<RoleRespModel> groupList = new List<RoleRespModel>();
+            using (OracleCommand cmd = con.CreateCommand())
+                {
+                cmd.CommandText = "pkg_fad.p_get_role_responsible";
+                cmd.CommandType = CommandType.StoredProcedure;
+                cmd.Parameters.Clear();
+                cmd.Parameters.Add("ENT_ID", OracleDbType.Int32).Value = loggedInUser.UserEntityID;
+                cmd.Parameters.Add("P_NO", OracleDbType.Int32).Value = loggedInUser.PPNumber;
+                cmd.Parameters.Add("R_ID", OracleDbType.Int32).Value = loggedInUser.UserRoleID;
+                cmd.Parameters.Add("T_CURSOR", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                OracleDataReader rdr = cmd.ExecuteReader();
+                while (rdr.Read())
+                    {
+                    RoleRespModel grp = new RoleRespModel();
+                    grp.DESIGNATIONCODE = Convert.ToInt32(rdr["DESIGNATIONCODE"]);
+                    grp.DESCRIPTION = rdr["DESCRIPTION"].ToString();
+                    groupList.Add(grp);
+                    }
+                }
+            con.Dispose();
+            return groupList;
+            }
+
+        public List<AuditeeEntitiesModel> GetProcOwnerForChecklistDetail()
+            {
+            var con = this.DatabaseConnection(); con.Open();
+            sessionHandler = new SessionHandler();
+            sessionHandler._httpCon = this._httpCon;
+            sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
+            var loggedInUser = sessionHandler.GetSessionUser();
+            List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
+            using (OracleCommand cmd = con.CreateCommand())
+                {
+                cmd.CommandText = "pkg_fad.p_get_process_owner";
+                cmd.CommandType = CommandType.StoredProcedure;
+                cmd.Parameters.Clear();
+                cmd.Parameters.Add("ENT_ID", OracleDbType.Int32).Value = loggedInUser.UserEntityID;
+                cmd.Parameters.Add("P_NO", OracleDbType.Int32).Value = loggedInUser.PPNumber;
+                cmd.Parameters.Add("R_ID", OracleDbType.Int32).Value = loggedInUser.UserRoleID;
+                cmd.Parameters.Add("T_CURSOR", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
+                OracleDataReader rdr = cmd.ExecuteReader();
+                while (rdr.Read())
+                    {
+                    AuditeeEntitiesModel entity = new AuditeeEntitiesModel();
+                    if (rdr["ENTITY_ID"].ToString() != "" && rdr["ENTITY_ID"].ToString() != null)
+                        entity.ENTITY_ID = Convert.ToInt32(rdr["ENTITY_ID"]);
+                    if (rdr["name"].ToString() != "" && rdr["name"].ToString() != null)
+                        entity.NAME = rdr["name"].ToString();
+                    entitiesList.Add(entity);
+                    }
+                }
+            con.Dispose();
+            return entitiesList;
+            }
          public string SaveCircularDocument(CircularDocumentModel model)
             {
             sessionHandler = new SessionHandler();

--- a/AIS/AIS/DBConnection.HD.cs
+++ b/AIS/AIS/DBConnection.HD.cs
@@ -1,3 +1,4 @@
+// Routes methods that call pkg_hd.* stored procedures.
 using AIS.Models;
 using Oracle.ManagedDataAccess.Client;
 using Oracle.ManagedDataAccess.Types;
@@ -9,35 +10,6 @@ namespace AIS.Controllers
 {
     public partial class DBConnection
     {
-        public List<RoleRespModel> GetRoleResponsibleForChecklistDetail()
-        {
-            sessionHandler = new SessionHandler();
-            sessionHandler._httpCon = this._httpCon;
-            sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
-            var loggedInUser = sessionHandler.GetSessionUser();
-            var con = this.DatabaseConnection(); con.Open();
-            List<RoleRespModel> groupList = new List<RoleRespModel>();
-            using (OracleCommand cmd = con.CreateCommand())
-            {
-                cmd.CommandText = "pkg_fad.p_get_role_responsible";
-                cmd.CommandType = CommandType.StoredProcedure;
-                cmd.Parameters.Clear();
-                cmd.Parameters.Add("ENT_ID", OracleDbType.Int32).Value = loggedInUser.UserEntityID;
-                cmd.Parameters.Add("P_NO", OracleDbType.Int32).Value = loggedInUser.PPNumber;
-                cmd.Parameters.Add("R_ID", OracleDbType.Int32).Value = loggedInUser.UserRoleID;
-                cmd.Parameters.Add("T_CURSOR", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
-                OracleDataReader rdr = cmd.ExecuteReader();
-                while (rdr.Read())
-                {
-                    RoleRespModel grp = new RoleRespModel();
-                    grp.DESIGNATIONCODE = Convert.ToInt32(rdr["DESIGNATIONCODE"]);
-                    grp.DESCRIPTION = rdr["DESCRIPTION"].ToString();
-                    groupList.Add(grp);
-                }
-            }
-            con.Dispose();
-            return groupList;
-        }
         public string GetUserName(string PPNUMBER)
         {
             string userName = "";
@@ -64,38 +36,6 @@ namespace AIS.Controllers
             }
             con.Dispose();
             return userName;
-        }
-
-        public List<AuditeeEntitiesModel> GetProcOwnerForChecklistDetail()
-        {
-            var con = this.DatabaseConnection(); con.Open();
-            sessionHandler = new SessionHandler();
-            sessionHandler._httpCon = this._httpCon;
-            sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
-            var loggedInUser = sessionHandler.GetSessionUser();
-            List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
-            {
-                cmd.CommandText = "pkg_fad.p_get_process_owner";
-                cmd.CommandType = CommandType.StoredProcedure;
-                cmd.Parameters.Clear();
-                cmd.Parameters.Add("ENT_ID", OracleDbType.Int32).Value = loggedInUser.UserEntityID;
-                cmd.Parameters.Add("P_NO", OracleDbType.Int32).Value = loggedInUser.PPNumber;
-                cmd.Parameters.Add("R_ID", OracleDbType.Int32).Value = loggedInUser.UserRoleID;
-                cmd.Parameters.Add("T_CURSOR", OracleDbType.RefCursor).Direction = ParameterDirection.Output;
-                OracleDataReader rdr = cmd.ExecuteReader();
-                while (rdr.Read())
-                {
-                    AuditeeEntitiesModel entity = new AuditeeEntitiesModel();
-                    if (rdr["ENTITY_ID"].ToString() != "" && rdr["ENTITY_ID"].ToString() != null)
-                        entity.ENTITY_ID = Convert.ToInt32(rdr["ENTITY_ID"]);
-                    if (rdr["name"].ToString() != "" && rdr["name"].ToString() != null)
-                        entity.NAME = rdr["name"].ToString();
-                    entitiesList.Add(entity);
-                }
-            }
-            con.Dispose();
-            return entitiesList;
         }
 
         public List<BranchModel> GetZoneBranches(int zone_code = 0, bool sessionCheck = true)


### PR DESCRIPTION
## Summary
- move FAD stored procedure helpers into `DBConnection.FAD` partial
- document package routing in `DBConnection.HD` and `DBConnection.FAD`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68985704ebf0832ea4b32edcb401c858