### PR TITLE
Add centralized plain text sanitization for varchar inputs

### DIFF
--- a/AIS/AIS/DBConnection.AD.cs
+++ b/AIS/AIS/DBConnection.AD.cs
@@ -16,7 +16,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<MenuModel> modelList = new List<MenuModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetAllTopMenus";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -50,7 +50,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<MenuPagesModel> modelList = new List<MenuPagesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_GetAllMenuPages";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -86,7 +86,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<MenuPagesModel> modelList = new List<MenuPagesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetAssignedMenuPages";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -122,7 +122,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_updateAllMenuPages";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -146,7 +146,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<GroupModel> groupList = new List<GroupModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetGroups";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -179,7 +179,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 if (gm.GROUP_ID == 0)
                     {
@@ -220,7 +220,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RoleRespModel> groupList = new List<RoleRespModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetRoleResponsibilities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -249,7 +249,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AnnexureModel> groupList = new List<AnnexureModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_annexure";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -303,7 +303,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_allusers";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -400,7 +400,7 @@ namespace AIS.Controllers
             string resp = "";
             var enc_pass = getMd5Hash(user.PASSWORD);
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_add_new_user";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -430,7 +430,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             List<AuditEntitiesModel> entitiesList = new List<AuditEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Entity_type";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -463,7 +463,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             List<AuditEntitiesModel> entitiesList = new List<AuditEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_audited_by";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -495,7 +495,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetAuditeeEntityTypes";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -529,7 +529,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetEntitees_for_update";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -585,7 +585,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntityUpdateModel> entitiesList = new List<AuditeeEntityUpdateModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetEntitees_for_update_comp";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -674,7 +674,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntityUpdateModel> entitiesList = new List<AuditeeEntityUpdateModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetEntitees_for_update_authorization";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -727,7 +727,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_ENTITIES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -767,7 +767,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_auditee_entities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -814,7 +814,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_CBAS_ENTITIES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -849,7 +849,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_ERP_ENTITIES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -884,7 +884,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_HR_ENTITIES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -914,7 +914,7 @@ namespace AIS.Controllers
         public AuditEntitiesModel AddAuditEntity(AuditEntitiesModel am)
             {
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_AddAuditEntity";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -932,7 +932,7 @@ namespace AIS.Controllers
             {
             List<AuditSubEntitiesModel> subEntitiesList = new List<AuditSubEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetAuditSubEntities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -970,7 +970,7 @@ namespace AIS.Controllers
                 }
 
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.UPDATE_USERS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1003,7 +1003,7 @@ namespace AIS.Controllers
             string userCCEmail = "";
             string userFullName = "";
             string successIndicator = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.RESET_USER_PASSWORD";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1035,7 +1035,7 @@ namespace AIS.Controllers
         public void AddGroupMenuItemsAssignment(int group_id = 0, int menu_item_id = 0)
             {
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_AddGroupMenuItemsAssignment";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1050,7 +1050,7 @@ namespace AIS.Controllers
         public void RemoveGroupMenuItemsAssignment(int group_id = 0, int menu_item_id = 0)
             {
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_RemoveGroupMenuItemsAssignment";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1076,7 +1076,7 @@ namespace AIS.Controllers
                 if (sessionCheck)
                     entityId = Convert.ToInt32(loggedInUser.PPNumber);
                 }
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetAuditZones";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1109,7 +1109,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<InspectionUnitsModel> ICList = new List<InspectionUnitsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.P_GetInspectionUnits";
@@ -1142,7 +1142,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<BranchModel> branchList = new List<BranchModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetBranches";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1179,7 +1179,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<ZoneModel> zoneList = new List<ZoneModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetZones";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1216,7 +1216,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<ZoneModel> zoneList = new List<ZoneModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetZonesForHoMointoring";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1252,7 +1252,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<BranchSizeModel> brSizeList = new List<BranchSizeModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetBranchSizes";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1276,7 +1276,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<ControlViolationsModel> controlViolationList = new List<ControlViolationsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetControlViolations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1302,7 +1302,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<SubEntitiesModel> entitiesList = new List<SubEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetSubEntities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1336,7 +1336,7 @@ namespace AIS.Controllers
         public SubEntitiesModel AddSubEntity(SubEntitiesModel subentity)
             {
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_AddSubEntity";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1355,7 +1355,7 @@ namespace AIS.Controllers
         public SubEntitiesModel UpdateSubEntity(SubEntitiesModel subentity)
             {
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UpdateSubEntity";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1381,7 +1381,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditRefEngagementPlanModel> list = new List<AuditRefEngagementPlanModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_audit_team_postchanges";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1418,7 +1418,7 @@ namespace AIS.Controllers
                 {
                 var con = this.DatabaseConnection(); con.Open();
 
-                using (OracleCommand cmd = con.CreateCommand())
+                using (OracleCommand cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "pkg_ad.p_get_allusers";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -1447,7 +1447,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessDetails> riskProcList = new List<RiskProcessDetails>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetRiskProcessDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1474,7 +1474,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<SubProcessUpdateModelForReviewAndAuthorizeModel> riskTransList = new List<SubProcessUpdateModelForReviewAndAuthorizeModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_sub_checklist_update_byid";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1505,7 +1505,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<ChecklistDetailComparisonModel> riskTransList = new List<ChecklistDetailComparisonModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_checklist_update_byid";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1559,7 +1559,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<ChecklistDetailComparisonModel> riskTransList = new List<ChecklistDetailComparisonModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_checklist_update_byid_ref";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1610,7 +1610,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessTransactions> riskTransList = new List<RiskProcessTransactions>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetRiskProcessTransactions";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1654,7 +1654,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<SubProcessUpdateModelForReviewAndAuthorizeModel> pmList = new List<SubProcessUpdateModelForReviewAndAuthorizeModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_Get_updated_Sub_Checklist_for_review";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1693,7 +1693,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessTransactions> riskTransList = new List<RiskProcessTransactions>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_Get_updated_Checklist_for_review";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1735,7 +1735,7 @@ namespace AIS.Controllers
         public RiskProcessDefinition AddRiskProcess(RiskProcessDefinition proc)
             {
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_audit_checklist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1755,7 +1755,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_audit_checklist_sub";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1779,7 +1779,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_audit_checklist_detail";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1805,7 +1805,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_Approved_Sub_Process_By_Authorizer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1834,7 +1834,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             string resp = "";
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_RefferedBack_Sub_checklist_By_Reviewer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1863,7 +1863,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Recommend_Checklist_By_Reviewer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1900,7 +1900,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_RefferedBack_checklist_By_Reviewer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1929,7 +1929,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             string resp = "";
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_approve_checklist_By_Authorizer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1958,7 +1958,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_RefferedBack_checklist_By_Authorizer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1983,7 +1983,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<RiskModel> riskList = new List<RiskModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetRisks";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2009,7 +2009,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditChecklistModel> list = new List<AuditChecklistModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.P_GET_SUBCHECKILIST";
@@ -2039,7 +2039,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditChecklistModel> list = new List<AuditChecklistModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.p_get_annexure_process";
@@ -2064,7 +2064,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             string response = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetLatestCommentsOnProcess";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2085,7 +2085,7 @@ namespace AIS.Controllers
             {
             List<SubCheckListStatus> list = new List<SubCheckListStatus>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_GET_SUB_CHECKLIST_MAKER";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2119,7 +2119,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_audit_checklist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2150,7 +2150,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_audit_checklist_update";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2182,7 +2182,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_audit_checklist_sub";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2214,7 +2214,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_audit_checklist_sub_update";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2248,7 +2248,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_GetChecklistDetailBySubProcessId";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2286,7 +2286,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_Get_ChecklistDetail_FOR_DUPLICATE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2324,7 +2324,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_checklistdetail_for_subchecklist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2354,7 +2354,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_GetChecklistDetail_ref";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2393,7 +2393,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_audit_checklist_detail";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2428,7 +2428,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.audit_checklist_detail_update";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2468,7 +2468,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Getchildposting";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2504,7 +2504,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Getparentrepoffice";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2540,7 +2540,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetAuditeeEntityTypes";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2571,7 +2571,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_COMPLIANCE_OFFICE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2601,7 +2601,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_COMPLIANCE_OFFICE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2630,7 +2630,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Getrealtionshiptype";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2657,7 +2657,7 @@ namespace AIS.Controllers
             {
             List<ObservationReversalModel> resp = new List<ObservationReversalModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_auditee_engagement";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2682,7 +2682,7 @@ namespace AIS.Controllers
             {
             List<ObservationReversalModel> resp = new List<ObservationReversalModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_audit_engagement";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2715,7 +2715,7 @@ namespace AIS.Controllers
             {
             List<EngagementObservationsForStatusReversalModel> resp = new List<EngagementObservationsForStatusReversalModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_audit_observtion";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2746,7 +2746,7 @@ namespace AIS.Controllers
             List<ObservationStatusReversalModel> stList = new List<ObservationStatusReversalModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_audit_observtion_status";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2772,7 +2772,7 @@ namespace AIS.Controllers
             List<ObservationStatusReversalModel> stList = new List<ObservationStatusReversalModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_audit_engagement_status";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2801,7 +2801,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditeeRiskModel> pdetails = new List<AuditeeRiskModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetAuditeeRisk";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2830,7 +2830,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RiskAssessmentEntTypeModel> pdetails = new List<RiskAssessmentEntTypeModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Entity_Risk";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2863,7 +2863,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditeeRiskModeldetails> pdetails = new List<AuditeeRiskModeldetails>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetAuditeeRisk_details";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2896,7 +2896,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_merge_checklist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2924,7 +2924,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_merge_sub_checklist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2951,7 +2951,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_REMOVE_DUPLICATE_CHECKLIST_DETAILS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2969,7 +2969,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditChecklistModel> list = new List<AuditChecklistModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.P_GET_DUPLICATE_CHECKLIST_DETAILS_DROPDOWN";
@@ -2998,7 +2998,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<MergeDuplicateProcessModel> list = new List<MergeDuplicateProcessModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.p_Get_Checklist_MERGER_FOR_REVIEW";
@@ -3032,7 +3032,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<MergeDuplicateProcessModel> list = new List<MergeDuplicateProcessModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.p_Get_sub_Checklist_MERGER_FOR_REVIEW";
@@ -3062,7 +3062,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<MergeDuplicateChecklistModel> list = new List<MergeDuplicateChecklistModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.P_GET_DUPLICATE_CHECKLIST_DETAILS";
@@ -3089,7 +3089,7 @@ namespace AIS.Controllers
             MergeDuplicateChecklistModel chk = new MergeDuplicateChecklistModel();
 
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.P_GET_DUPLICATE_CHECKLIST_DETAILS_COUNT";
@@ -3113,7 +3113,7 @@ namespace AIS.Controllers
             {
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.P_AUTHORIZE_MERGER_CHECKLIST";
@@ -3138,7 +3138,7 @@ namespace AIS.Controllers
             {
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.P_AUTHORIZE_MERGER_CHECKLIST_SUB";
@@ -3163,7 +3163,7 @@ namespace AIS.Controllers
             {
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ad.P_AUTHORIZE_DUPLICATE_CHECKLIST_DETAILS";
@@ -3192,7 +3192,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_audit_observation_reversal";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3220,7 +3220,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AdminNewUsersAIS> resp = new List<AdminNewUsersAIS>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_new_user";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3257,7 +3257,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<HREntitiesModel> resp = new List<HREntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_HR_ENTITIES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3296,7 +3296,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AISEntitiesModel> resp = new List<AISEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_AIS_ENTITIES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3336,7 +3336,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UpdateENTITIEES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3373,7 +3373,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_InsertENTITIEES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3409,7 +3409,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<EntityMappingForEntityAddition> respOut = new List<EntityMappingForEntityAddition>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_auditee_entities_mapping";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3450,7 +3450,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_ENTITIES_MAPPING";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3480,7 +3480,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_ADD_ENTITIES_MAPPING";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3510,7 +3510,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_NEW_USER";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3538,7 +3538,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<UserRoleDetailAdminPanelModel> resp = new List<UserRoleDetailAdminPanelModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_user_role_type";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3570,7 +3570,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<EntitiesShiftingDetailsModel> resp = new List<EntitiesShiftingDetailsModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_details_for_entity_shifting";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3613,7 +3613,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditEntitiesModel> resp = new List<AuditEntitiesModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Entities_types";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3651,7 +3651,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_update_Entities_types";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3684,7 +3684,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditEntityRelationsModel> resp = new List<AuditEntityRelationsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Entities_Relationship";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3725,7 +3725,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<EntitiesMappingModel> resp = new List<EntitiesMappingModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_ENTITIES_MAPPING";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3769,7 +3769,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<EntitiesMappingModel> resp = new List<EntitiesMappingModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_ENTITIES_MAPPING_REPORTING";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3813,7 +3813,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<EntitiesMappingModel> resp = new List<EntitiesMappingModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_entities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3845,7 +3845,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Add_Entity_shifting";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3880,7 +3880,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Shift_BR_to_islamic";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3907,7 +3907,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<GroupModel> groupList = new List<GroupModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_roles_for_compliance_flow";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3940,7 +3940,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<GroupModel> groupList = new List<GroupModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GetRoleResponsibilities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3973,7 +3973,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_ent_types_for_compliance_flow";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4006,7 +4006,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_ent_types_for_hr_designation";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4039,7 +4039,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_compliance_statuses_for_compliance_flow";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4069,7 +4069,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ComplianceFlowModel> resp = new List<ComplianceFlowModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_entity_type_compliance_flow";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4116,7 +4116,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_ADD_UPDATE_COMPLIANCE_FLOW";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4150,7 +4150,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_COMPLIANCE_FLOW";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4182,7 +4182,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_audit_team_postchanges";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4213,7 +4213,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_audit_engagement_reversal";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4247,7 +4247,7 @@ namespace AIS.Controllers
             string resp = "";
             foreach (int obsId in OBS_IDS)
                 {
-                using (OracleCommand cmd = con.CreateCommand())
+                using (OracleCommand cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "pkg_ad.p_audit_observation_reversal";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -4279,7 +4279,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ObservationNumbersModel> resp = new List<ObservationNumbersModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_observvation_no";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4312,7 +4312,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Update_observation_no";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4343,7 +4343,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_ENG_DATE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4374,7 +4374,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<HRDesignationWiseRoleModel> resp = new List<HRDesignationWiseRoleModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_HR_DESIGNATION_RIGHT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4409,7 +4409,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_ADD_HR_DESIGNATION_RIGHT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4438,7 +4438,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_HR_DESIGNATION_RIGHT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4470,7 +4470,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ManageObservationModel> resp = new List<ManageObservationModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Obs_Status";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4503,7 +4503,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_add_Obs_status";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4535,7 +4535,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_update_Obs_status";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4568,7 +4568,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ManageEntAuditDeptModel> resp = new List<ManageEntAuditDeptModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Entities_Audit_Department";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4605,7 +4605,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_add_Entities_Audit_Department";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4640,7 +4640,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_update_entities_audit_department";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4676,7 +4676,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<MenuModel> resp = new List<MenuModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_ALL_MENU";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4708,7 +4708,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<SubMenuModel> resp = new List<SubMenuModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_SUB_MENUS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4743,7 +4743,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_ADD_NEW_SUB_MENU";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4775,7 +4775,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_SUB_MENU";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4809,7 +4809,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<MenuPagesAssignmentModel> resp = new List<MenuPagesAssignmentModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_ALL_PAGES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4849,7 +4849,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_ADD_NEW_PAGE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4883,7 +4883,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_PAGE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4916,7 +4916,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_ENTITY_COMP";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4945,7 +4945,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_ADD_ANNEXURE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -4983,7 +4983,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_update_annexure";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5023,7 +5023,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_ENTITY_FOR_PARA_Reconsilation";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5053,7 +5053,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_add_branch_risk_rating";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5079,7 +5079,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<TraditionalRiskRatingModel> resp = new List<TraditionalRiskRatingModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_traditional_risk_rating";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5115,7 +5115,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_add_branch_annex_risk_rating";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5141,7 +5141,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<TraditionalRiskRatingModel> resp = new List<TraditionalRiskRatingModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_annexure_risk_rating";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5175,7 +5175,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<RiskRatingModelForBranchesWorking> resp = new List<RiskRatingModelForBranchesWorking>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_new_risk_model ";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5223,7 +5223,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ComplianceHierarchyModel> resp = new List<ComplianceHierarchyModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.p_get_compliance_hierarchy ";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5256,7 +5256,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_ADD_COM_OFFICER";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5284,7 +5284,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_COM_OFFICER";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5315,7 +5315,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_GM_OFFICE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5344,7 +5344,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_RPT_OFFICE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5371,7 +5371,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_GM_OFFICE_RELATIONSHIP";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5397,7 +5397,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_UPDATE_RPT_OFFICE_RELATIONSHIP";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5420,7 +5420,7 @@ namespace AIS.Controllers
             List<AISPostComplianceModel> list = new List<AISPostComplianceModel>();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_latest_para_details";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5455,7 +5455,7 @@ namespace AIS.Controllers
             string resp = "";
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Update_para_AIS_post_compliance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5491,7 +5491,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADAuditEmpModel> list = new List<FADAuditEmpModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Audit_EMP";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5526,7 +5526,7 @@ namespace AIS.Controllers
             {
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_update_audit_emp";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5558,7 +5558,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADAuditManpowerModel> list = new List<FADAuditManpowerModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Audit_Manpower";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5587,7 +5587,7 @@ namespace AIS.Controllers
             {
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_update_audit_manpower";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5615,7 +5615,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADAuditBudgetModel> list = new List<FADAuditBudgetModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_Get_Audit_budget";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5647,7 +5647,7 @@ namespace AIS.Controllers
             {
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_update_audit_budget";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5673,7 +5673,7 @@ namespace AIS.Controllers
             {
             List<DropDownModel> list = new List<DropDownModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_hr_rank";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5696,7 +5696,7 @@ namespace AIS.Controllers
             {
             List<DropDownModel> list = new List<DropDownModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_hr_designation";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5719,7 +5719,7 @@ namespace AIS.Controllers
             {
             List<DropDownModel> list = new List<DropDownModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_hr_posting";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5742,7 +5742,7 @@ namespace AIS.Controllers
             {
             List<DropDownModel> list = new List<DropDownModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_qualification";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5765,7 +5765,7 @@ namespace AIS.Controllers
             {
             List<DropDownModel> list = new List<DropDownModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_qualification_specialization";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5788,7 +5788,7 @@ namespace AIS.Controllers
             {
             List<DropDownModel> list = new List<DropDownModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_certification";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5811,7 +5811,7 @@ namespace AIS.Controllers
             {
             List<DropDownModel> list = new List<DropDownModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_get_GL_Heads";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5838,7 +5838,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<PublicHolidayModel> list = new List<PublicHolidayModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_PUBLIC_HOLIDAYS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -5870,7 +5870,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<PublicHolidayModel> list = new List<PublicHolidayModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ad.P_GET_PUBLIC_HOLIDAY_DAY";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.AE.cs
+++ b/AIS/AIS/DBConnection.AE.cs
@@ -13,7 +13,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<RiskModel> riskList = new List<RiskModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.p_GetCOSORisks";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -42,7 +42,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AssignedObservations> list = new List<AssignedObservations>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.p_GetAssignedObservations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -87,7 +87,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             List<AssignedObservations> list = new List<AssignedObservations>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetAssignedObservationsForBranch";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -135,7 +135,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             List<ObservationResponsiblePPNOModel> list = new List<ObservationResponsiblePPNOModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetObservationResponsible";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -166,7 +166,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             List<ObservationResponsiblePPNOModel> list = new List<ObservationResponsiblePPNOModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.p_GetParaComplianceResponsible";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -203,7 +203,7 @@ namespace AIS.Controllers
                     {
                     con.Open();
 
-                    using (var cmd = con.CreateCommand())
+                    using (var cmd = CreateSanitizedCommand(con))
                         {
                         cmd.CommandText = "pkg_ae.P_GetPostAuditCompliance_Evidence";
                         cmd.CommandType = CommandType.StoredProcedure;
@@ -251,7 +251,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             List<AuditeeResponseEvidenceModel> list = new List<AuditeeResponseEvidenceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetPostAuditCompliance_Evidence";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -294,7 +294,7 @@ namespace AIS.Controllers
             ob.REMARKS = "";
             ob.SUBMITTED = "Y";
             ob.REPLY_ROLE = 0;
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_AUDITEE_OBSERVATION_RESPONSE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -358,7 +358,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeOldParasModel> list = new List<AuditeeOldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetAuditeeOldParasentitiesFAD";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -390,7 +390,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeOldParasModel> list = new List<AuditeeOldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetAuditeeOldParas";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -448,7 +448,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<OldParasModelCAD> list = new List<OldParasModelCAD>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetOldParaManagement";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -488,7 +488,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_updateoldparamanagement";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -519,7 +519,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_UpdateAuditeeOldParasresponse";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -550,7 +550,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> list = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetAuditeeAssignedEntities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -580,7 +580,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> list = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetCCQsEntities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -609,7 +609,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GetOldParasBranchComplianceModel> list = new List<GetOldParasBranchComplianceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForComplianceByAuditee";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -657,7 +657,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GetOldParasBranchComplianceModel> list = new List<GetOldParasBranchComplianceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForCompliancereview ";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -709,7 +709,7 @@ namespace AIS.Controllers
             GetOldParasBranchComplianceTextModel chk = new GetOldParasBranchComplianceTextModel();
 
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForComplianceByAuditee_text";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -741,7 +741,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             GetOldParasBranchComplianceTextModel resp = new GetOldParasBranchComplianceTextModel();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForComplianceforhistory";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -770,7 +770,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             var resp = new AuditeeResponseEvidenceModel();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetPostAuditCompliance_Evidence_FileData";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -809,7 +809,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             var resp = new AuditeeResponseEvidenceModel();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetPostAuditCompliance_Evidence_FileData_CAU";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -848,7 +848,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             GetOldParasBranchComplianceTextModel chk = new GetOldParasBranchComplianceTextModel();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetAuditeeOldParasFADText_Ref";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -879,7 +879,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             GetOldParasBranchComplianceTextModel chk = new GetOldParasBranchComplianceTextModel();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetAuditeeOldParasFADtext_Reviewer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -910,7 +910,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             GetOldParasBranchComplianceTextModel chk = new GetOldParasBranchComplianceTextModel();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetAuditeeOldParasFADtext_Reviewer_Ref";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -944,7 +944,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_SubmitPostAuditCompliance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1016,7 +1016,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_SubmitPostAuditCompliance_review";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1061,7 +1061,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GetOldParasForComplianceReviewer> list = new List<GetOldParasForComplianceReviewer>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.p_getoldparasforreviewer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1104,7 +1104,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GetOldParasForComplianceReviewer> list = new List<GetOldParasForComplianceReviewer>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.p_getoldparasforreviewer_ref";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1147,7 +1147,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_AddOldParasReviewer";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1184,7 +1184,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             bool success = false;
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_AddOldParasReply";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1207,7 +1207,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GetOldParasBranchComplianceModel> list = new List<GetOldParasBranchComplianceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetAuditeeAllParasFAD";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1237,7 +1237,7 @@ namespace AIS.Controllers
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_get_v_auditee_paras_compliance_history_auditee_text";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1260,7 +1260,7 @@ namespace AIS.Controllers
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_get_v_auditee_paras_compliance_history_num_auditee";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1285,7 +1285,7 @@ namespace AIS.Controllers
             List<PostComplianceHistoryModel> stList = new List<PostComplianceHistoryModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForCompliancehistory";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1325,7 +1325,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<CAUParaForComplianceModel> list = new List<CAUParaForComplianceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForComplianceByCAU";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1364,7 +1364,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetrealtionshiptypeforCAU";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1395,7 +1395,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
 
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetparentrepofficeforCAU";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1433,7 +1433,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetchildpostingforCAU";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1466,7 +1466,7 @@ namespace AIS.Controllers
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_FORWARD_CAU_PARA_TO_BRANCH";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1497,7 +1497,7 @@ namespace AIS.Controllers
             ParaTextModel resp = new ParaTextModel();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForCompliance_CAU_para_text";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1527,7 +1527,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<CAUParaForComplianceModel> list = new List<CAUParaForComplianceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForComplianceByCAU_BY_BRANCH";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1567,7 +1567,7 @@ namespace AIS.Controllers
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_SubmitPostAuditCompliance_BY_BRANCH";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1628,7 +1628,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<CAUParaForComplianceModel> list = new List<CAUParaForComplianceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ae.P_GetParasForComplianceByCAU_FOR_REVIEW";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1671,7 +1671,7 @@ namespace AIS.Controllers
                     {
                     con.Open();
 
-                    using (var cmd = con.CreateCommand())
+                    using (var cmd = CreateSanitizedCommand(con))
                         {
                         cmd.CommandText = "pkg_ae.P_GetAllCompliance_Evidence_CAU";
                         cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.AI.cs
+++ b/AIS/AIS/DBConnection.AI.cs
@@ -18,7 +18,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GlHeadDetailsModel> list = new List<GlHeadDetailsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
             {
                 cmd.CommandText = "pkg_ai.p_getglheadsummary";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.AIS.cs
+++ b/AIS/AIS/DBConnection.AIS.cs
@@ -18,7 +18,7 @@ namespace AIS.Controllers
             sessionHandler._httpCon = this._httpCon;
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
             {
                 cmd.CommandText = "pkg_ais.P_GetAuditeeEntitiesForOldParas";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -51,7 +51,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditPlanModel> planList = new List<AuditPlanModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
             {
                 string _sql = "pkg_ais.p_get_audit_plan";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.AR.cs
+++ b/AIS/AIS/DBConnection.AR.cs
@@ -18,7 +18,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             List<AuditEntitiesModel> entitiesList = new List<AuditEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_get_auditee_submission_list";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -45,7 +45,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<RiskGroupModel> riskgroupList = new List<RiskGroupModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetRiskGroup";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -70,7 +70,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<RiskSubGroupModel> risksubgroupList = new List<RiskSubGroupModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetRiskSubGroup";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -97,7 +97,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<RiskActivityModel> riskActivityList = new List<RiskActivityModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_GetRiskActivities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -124,7 +124,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditVoilationcatModel> voilationList = new List<AuditVoilationcatModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetAuditVoilationcats";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -149,7 +149,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditSubVoilationcatModel> voilationsubgroupList = new List<AuditSubVoilationcatModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetVoilationSubGroup";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -184,7 +184,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             List<TaskListModel> tasklist = new List<TaskListModel>();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetTaskList";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -242,7 +242,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             if (engId == 0)
                 engId = this.GetLoggedInUserEngId();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetJoiningDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -300,7 +300,7 @@ namespace AIS.Controllers
                 jm.ENTEREDBY = Convert.ToInt32(loggedInUser.PPNumber);
                 jm.ENTEREDDATE = DateTime.Now;
 
-                using (OracleCommand cmd = con.CreateCommand())
+                using (OracleCommand cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "pkg_ar.P_AddJoiningReport";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -341,7 +341,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditChecklistModel> list = new List<AuditChecklistModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_GetAuditChecklist";
@@ -371,7 +371,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditChecklistModel> list = new List<AuditChecklistModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_GetAuditChecklistCAD";
@@ -403,7 +403,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditChecklistSubModel> list = new List<AuditChecklistSubModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_GetAuditChecklistSub";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -454,7 +454,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditChecklistDetailsModel> list = new List<AuditChecklistDetailsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetAuditChecklistDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -509,7 +509,7 @@ namespace AIS.Controllers
             var INDICATOR = "A";
             if (ob.ENGPLANID == 0)
                 ob.ENGPLANID = this.GetLoggedInUserEngId();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_SaveAuditObservation";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -594,7 +594,7 @@ namespace AIS.Controllers
             var INDICATOR = "A";
             if (ob.ENGPLANID == 0)
                 ob.ENGPLANID = this.GetLoggedInUserEngId();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_SaveAuditObservationCAD";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -670,7 +670,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             int ENG_ID = this.GetLoggedInUserEngId();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_SetEngIdOnHold";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -691,7 +691,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string response = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetLatestAuditorResponse";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -719,7 +719,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string response = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetLatestDepartmentalHeadResponse";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -747,7 +747,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string response = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetLatestAuditeeResponse";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -776,7 +776,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ObservationSummaryModel> list = new List<ObservationSummaryModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_get_details_for_manage_observations_summary";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -820,7 +820,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ObservationRevisedModel> list = new List<ObservationRevisedModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_get_details_for_manage_observations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -872,7 +872,7 @@ namespace AIS.Controllers
 
                     var loggedInUser = sessionHandler.GetSessionUser();
 
-                    using (OracleCommand cmd = con.CreateCommand())
+                    using (OracleCommand cmd = CreateSanitizedCommand(con))
                         {
                         cmd.CommandText = "pkg_ar.P_GetObservationsForManageAuditParas";
                         cmd.CommandType = CommandType.StoredProcedure;
@@ -928,7 +928,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ManageAuditParasModel> list = new List<ManageAuditParasModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GET_Para_details_for_Authorize";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -976,7 +976,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ManageAuditParasModel> list = new List<ManageAuditParasModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GET_Para_changes_for_Authorize";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1023,7 +1023,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_Update_Audit_Paras";
@@ -1066,7 +1066,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_Authorize_Update_Audit_Paras";
@@ -1109,7 +1109,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_Authorize_Update_Audit_Paras";
@@ -1153,7 +1153,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ManageObservations> list = new List<ManageObservations>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetManagedObservations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1198,7 +1198,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ManageObservations> list = new List<ManageObservations>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetManagedObservationsText";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1237,7 +1237,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeResponseEvidenceModel> modellist = new List<AuditeeResponseEvidenceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_get_AUDITEE_OBSERVATION_RESPONSE_evidences_by_obs_id";
@@ -1270,7 +1270,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ObservationTextModel> list = new List<ObservationTextModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_get_details_for_manage_observations_text";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1315,7 +1315,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             List<ManageObservations> list = new List<ManageObservations>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetManagedObservationsForBranches";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1372,7 +1372,7 @@ namespace AIS.Controllers
             if (loggedInUser.UserEntityID == 112242 || loggedInUser.UserEntityID == 112248)
                 {
 
-                using (OracleCommand cmd = con.CreateCommand())
+                using (OracleCommand cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "pkg_ar.P_GetManagedObservationstext";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -1406,7 +1406,7 @@ namespace AIS.Controllers
                 }
             else
                 {
-                using (OracleCommand cmd = con.CreateCommand())
+                using (OracleCommand cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "pkg_ar.P_GetManagedObservationsForBranchesText";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -1456,7 +1456,7 @@ namespace AIS.Controllers
             if (ENG_ID == 0)
                 ENG_ID = this.GetLoggedInUserEngId();
             List<ManageObservations> list = new List<ManageObservations>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetManagedDraftObservations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1507,7 +1507,7 @@ namespace AIS.Controllers
             if (ENG_ID == 0)
                 ENG_ID = this.GetLoggedInUserEngId();
             List<ManageObservations> list = new List<ManageObservations>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetManagedDraftObservationsForBranches";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1558,7 +1558,7 @@ namespace AIS.Controllers
             if (ENG_ID == 0)
                 ENG_ID = this.GetLoggedInUserEngId();
             List<ManageObservations> list = new List<ManageObservations>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetManagedDraftObservationsbranch";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1611,7 +1611,7 @@ namespace AIS.Controllers
             if (ENG_ID == 0)
                 ENG_ID = this.GetLoggedInUserEngId();
             List<ManageObservations> list = new List<ManageObservations>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetManagedDraftObservationsText";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1641,7 +1641,7 @@ namespace AIS.Controllers
                 ENG_ID = this.GetLoggedInUserEngId();
             List<ManageObservations> list = new List<ManageObservations>();
             List<ManageObservations> finalList = new List<ManageObservations>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetManagedDraftObservationsForBranches";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1692,7 +1692,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             if (ENG_ID == 0)
                 ENG_ID = this.GetLoggedInUserEngId();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_getauditeecheckklist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1727,7 +1727,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_DropAuditObservation";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1754,7 +1754,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_SubmitAuditObservationToAuditee";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1802,7 +1802,7 @@ namespace AIS.Controllers
             else if (NEW_STATUS_ID == 9)
                 Remarks = "Para settle in discussion";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_UpdateAuditObservationStatus";
@@ -1870,7 +1870,7 @@ namespace AIS.Controllers
             else if (NEW_STATUS_ID == 9)
                 Remarks = "Para settle in discussion";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_UpdateAuditObservationStatusByHead";
@@ -1928,7 +1928,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_UpdateObservation";
@@ -1964,7 +1964,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             List<ClosingDraftTeamDetailsModel> list = new List<ClosingDraftTeamDetailsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_GetClosingDraftObservations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2019,7 +2019,7 @@ namespace AIS.Controllers
                 ENG_ID = this.GetLoggedInUserEngId();
             List<ClosingDraftTeamDetailsModel> list = new List<ClosingDraftTeamDetailsModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_GetClosingDraftObservations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2066,7 +2066,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<SearchChecklistDetailsModel> list = new List<SearchChecklistDetailsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetAuditChecklistDetails_search";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2097,7 +2097,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeOldParasModel> list = new List<AuditeeOldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetEntitiesForLegacyPara";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2128,7 +2128,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeOldParasModel> list = new List<AuditeeOldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetEntitiesForLegacyPara_HO";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2157,7 +2157,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeOldParasModel> list = new List<AuditeeOldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetEntitiesForLegacyPara_ho_report";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2186,7 +2186,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<OldParasModel> list = new List<OldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
 
                 {
                 cmd.CommandText = "pkg_ar.P_GetLeagacyObservations";
@@ -2247,7 +2247,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<OldParasModel> list = new List<OldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
 
                 {
                 cmd.CommandText = "pkg_ar.P_GetLeagacyObservations_ho";
@@ -2303,7 +2303,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<OldParasModel> list = new List<OldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
 
                 {
                 cmd.CommandText = "pkg_ar.P_GetLeagacyObservations_for_gist_update";
@@ -2352,7 +2352,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_update_legacy_Para_text";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2423,7 +2423,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_update_legacy_Para_Gist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2454,7 +2454,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_add_para_responsibility";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2489,7 +2489,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_delete_para_responsibility";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2517,7 +2517,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_no_update_legacy_Para_text";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2553,7 +2553,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> list = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_get_entities_for_manage_observations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2584,7 +2584,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> list = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_GetManageAuditParasEntities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2615,7 +2615,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> list = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_GetObservationEntities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2646,7 +2646,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             var resp = new AuditeeResponseEvidenceModel();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_get_AUDITEE_OBSERVATION_RESPONSE_evidences_FileData";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2687,7 +2687,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             if (ENG_ID == 0)
                 ENG_ID = this.GetLoggedInUserEngId();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_CloseAudit";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2715,7 +2715,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ObservationResponsiblePPNOModel> list = new List<ObservationResponsiblePPNOModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.p_get_legacy_para_responsibles";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2749,7 +2749,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             UserModel um = new UserModel();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = " pkg_ar.P_get_employees_information";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2777,7 +2777,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_get_legacy_para_to_authorize";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2815,7 +2815,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_Authorize_Para_Gist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2845,7 +2845,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_Settel_Legacy_Para_HO";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2873,7 +2873,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_Delete_Legacy_Para_HO";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2901,7 +2901,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanCaseFileDetailsModel> resp = new List<LoanCaseFileDetailsModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetLoanCaseFile";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2939,7 +2939,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_AddLoanCaseFile";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2976,7 +2976,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<VoucherCheckingDetailsModel> resp = new List<VoucherCheckingDetailsModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetVoucherChecking";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3011,7 +3011,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_AddVoucherChecking";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3045,7 +3045,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AccountOpeningDetailsModel> resp = new List<AccountOpeningDetailsModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetAccountOpeningDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3081,7 +3081,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_AddAccountOpeningDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3116,7 +3116,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FixedAssetsDetailsModel> resp = new List<FixedAssetsDetailsModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetFixedAssetsDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3153,7 +3153,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_AddFixedAssetsDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3189,7 +3189,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<CashCountDetailsModel> resp = new List<CashCountDetailsModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GetCashCounterDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3228,7 +3228,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_AddCashCounterDetails";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3266,7 +3266,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<DraftDSAGuidelines> resp = new List<DraftDSAGuidelines>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_get_dsa_guidline";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3299,7 +3299,7 @@ namespace AIS.Controllers
             int DSA_ID = 0;
             List<Object> outRec = new List<object>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_draft_dsa";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3333,7 +3333,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_add_dsa_checkilist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3356,7 +3356,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ObservationResponsiblePPNOModel> list = new List<ObservationResponsiblePPNOModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_Get_responsibility";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3398,7 +3398,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_responibilityassigned";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3436,7 +3436,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_Update_responsibility";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3477,7 +3477,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_draft_dsa";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3511,7 +3511,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<DraftDSAList> resp = new List<DraftDSAList>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_get_dsa_list";
@@ -3566,7 +3566,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             DSAContentModel resp = new DSAContentModel();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_ar.P_get_dsa_content";
@@ -3600,7 +3600,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_submit_dsa_to_head_fad";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3625,7 +3625,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_update_dsa_heading";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3654,7 +3654,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_reffered_back_dsa_by_head_fad";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3679,7 +3679,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_submit_dsa_by_head_fad_to_dpd";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3704,7 +3704,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_reffered_back_dsa_by_dpd";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3729,7 +3729,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_submit_dsa_by_dpd_to_committee";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -3754,7 +3754,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanCaseDetailModel> list = new List<LoanCaseDetailModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_ar.P_GET_LC_DETAILS";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.CA.cs
+++ b/AIS/AIS/DBConnection.CA.cs
@@ -22,7 +22,7 @@ namespace AIS.Controllers
 
             List<CAObservation> observations = new List<CAObservation>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.GET_OBSERVATIONS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -66,7 +66,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection();
             con.Open();
             int observationId = 0;
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.ADD_OBSERVATION";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -92,7 +92,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.SUBMIT_TO_HEADFAD";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -111,7 +111,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.ASSIGN_DIVISION";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -131,7 +131,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.ASSIGN_DEPARTMENT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -151,7 +151,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.DEPARTMENT_RESPONSE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -173,7 +173,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.REVIEW_AND_FORWARD";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -194,7 +194,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.REJECT_OR_REFER_BACK";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -214,7 +214,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.FINALIZE_OBSERVATION";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -234,7 +234,7 @@ namespace AIS.Controllers
             var form = request.Form;
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_CA.ENTER_LEGACY";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.DB.cs
+++ b/AIS/AIS/DBConnection.DB.cs
@@ -16,7 +16,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessDefinition> pdetails = new List<RiskProcessDefinition>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_names";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -47,7 +47,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessDefinition> pdetails = new List<RiskProcessDefinition>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_names_checklist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -79,7 +79,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessDefinition> pdetails = new List<RiskProcessDefinition>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_names_checklist_sub";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -111,7 +111,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessDefinition> pdetails = new List<RiskProcessDefinition>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_names_ho";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -142,7 +142,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessDefinition> pdetails = new List<RiskProcessDefinition>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_names_checklist_ho";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -169,7 +169,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<RiskProcessDefinition> pdetails = new List<RiskProcessDefinition>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_names_checklist_sub_ho";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -203,7 +203,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Getchildposting";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -230,7 +230,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Getparentrepoffice";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -264,7 +264,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Getrealtionshiptype";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -296,7 +296,7 @@ namespace AIS.Controllers
 
             List<FunctionalResponsibilityWiseParas> list = new List<FunctionalResponsibilityWiseParas>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GetFunctionalResponsibilityWisePara";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -343,7 +343,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FunctionalResponsibilitiesWiseParasModel> list = new List<FunctionalResponsibilitiesWiseParasModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -384,7 +384,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADNewOldParaPerformanceModel> list = new List<FADNewOldParaPerformanceModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_ho";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -424,7 +424,7 @@ namespace AIS.Controllers
 
             List<FADNewOldParaPerformanceModel> list = new List<FADNewOldParaPerformanceModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_v_wise";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -461,7 +461,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADNewOldParaPerformanceModel> list = new List<FADNewOldParaPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_old";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -497,7 +497,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADNewOldParaPerformanceModel> list = new List<FADNewOldParaPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_new";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -533,7 +533,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADNewOldParaPerformanceModel> list = new List<FADNewOldParaPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -569,7 +569,7 @@ namespace AIS.Controllers
 
             List<NoEntitiesRiskBasePlan> list = new List<NoEntitiesRiskBasePlan>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.p_get_risk_baseplan";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -600,7 +600,7 @@ namespace AIS.Controllers
 
             List<FADAuditPerformanceModel> list = new List<FADAuditPerformanceModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_AUDIT_PERFORMANCE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -634,7 +634,7 @@ namespace AIS.Controllers
 
             List<AuditPerformanceChartDashboardModel> list = new List<AuditPerformanceChartDashboardModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.p_get_dashborad_scorecard";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -667,7 +667,7 @@ namespace AIS.Controllers
 
             List<RepetativeParaModel> list = new List<RepetativeParaModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.p_get_dash_repetitive";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -714,7 +714,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<EntityWiseObservationModel> pdetails = new List<EntityWiseObservationModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Functional_Reporting_office_WISE_ANALYSIS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -750,7 +750,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<EntityWiseObservationModel> pdetails = new List<EntityWiseObservationModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Functional_ENTITY_WISE_ANALYSIS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -787,7 +787,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<AnnexWiseObservationModel> pdetails = new List<AnnexWiseObservationModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Functional_ANALYSIS_DETAILS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -825,7 +825,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<AnnexWiseObservationModel> pdetails = new List<AnnexWiseObservationModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Function_Annexure";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -855,7 +855,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<FunctionalAnnexureWiseObservationModel> pdetails = new List<FunctionalAnnexureWiseObservationModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Functional_ENTITY_WISE_Paras";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -893,7 +893,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<FunctionalAnnexureWiseObservationModel> pdetails = new List<FunctionalAnnexureWiseObservationModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Function_Annexure_Paras";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -929,7 +929,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             string resp = "";
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_Function_Annexure_Paras_text";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -956,7 +956,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<FunctionalAnnexureWiseObservationModel> pdetails = new List<FunctionalAnnexureWiseObservationModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_PARA";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -990,7 +990,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
 
             List<FunctionalAnnexureWiseObservationModel> pdetails = new List<FunctionalAnnexureWiseObservationModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_GET_Dash_table_functionwise_PARA_summary";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1025,7 +1025,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ComplianceSummaryModel> resp = new List<ComplianceSummaryModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_db.P_compliance_summary";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.FAD.cs
+++ b/AIS/AIS/DBConnection.FAD.cs
@@ -19,7 +19,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RoleRespModel> groupList = new List<RoleRespModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_fad.p_get_role_responsible";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -49,7 +49,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_fad.p_get_process_owner";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -83,7 +83,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_InsertCircularDoc";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -113,7 +113,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_InsertCircularDoc";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -135,7 +135,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_GetCircularDoc";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -177,7 +177,7 @@ namespace AIS.Controllers
             var list = new List<AuditChecklistAnnexureCircularModel>();
             var con = this.DatabaseConnection();
             con.Open();
-            using (var cmd = con.CreateCommand())
+            using (var cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_FAD.P_GetAuditChecklistAnnexureCirculars";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -220,7 +220,7 @@ namespace AIS.Controllers
             con.Open();
 
             var list = new List<AuditEmployeeModel>();
-            using (var cmd = con.CreateCommand())
+            using (var cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_FAD.P_GetAuditEmployees";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -263,7 +263,7 @@ namespace AIS.Controllers
             con.Open();
 
             var list = new List<IdNameModel>();
-            using (var cmd = con.CreateCommand())
+            using (var cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_FAD.P_GetRelationTypes";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -296,7 +296,7 @@ namespace AIS.Controllers
             con.Open();
 
             var list = new List<IdNameModel>();
-            using (var cmd = con.CreateCommand())
+            using (var cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_FAD.P_GetReportingOffices";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -331,7 +331,7 @@ namespace AIS.Controllers
             con.Open();
 
             var list = new List<EntityModel>();
-            using (var cmd = con.CreateCommand())
+            using (var cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_FAD.P_GetEntitiesForOffice";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -366,7 +366,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             string result = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_fad.P_allocate_entity_to_auditor";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -401,7 +401,7 @@ namespace AIS.Controllers
             con.Open();
 
             var list = new List<ObservationReferenceModel>();
-            using (var cmd = con.CreateCommand())
+            using (var cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_FAD.P_GetObservationsForReferenceUpdate";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -458,7 +458,7 @@ namespace AIS.Controllers
             con.Open();
 
             var list = new List<UpdateLogModel>();
-            using (var cmd = con.CreateCommand())
+            using (var cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_FAD.P_GetReferenceUpdateLog";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -495,7 +495,7 @@ namespace AIS.Controllers
             con.Open();
 
             var list = new List<ReferenceSearchResultModel>();
-            using (var cmd = con.CreateCommand())
+            using (var cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_FAD.P_SearchReferences";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -529,7 +529,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_GetPendingParas";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -566,7 +566,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_GetEntityTaskSummary";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -603,7 +603,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_GetEntityTaskSummary";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -636,7 +636,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_GetPendingReferenceParas";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -695,7 +695,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_GetParaReferences";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -734,7 +734,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_GetParaReferences";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -758,7 +758,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_GetParaText";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -801,7 +801,7 @@ namespace AIS.Controllers
             using (var con = this.DatabaseConnection())
                 {
                 con.Open();
-                using (var cmd = con.CreateCommand())
+                using (var cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "PKG_FAD.P_ManageReference";
                     cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.HD.cs
+++ b/AIS/AIS/DBConnection.HD.cs
@@ -18,7 +18,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
             {
                 cmd.CommandText = "pkg_hd.p_ppno_name";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -46,7 +46,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<BranchModel> branchList = new List<BranchModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
             {
                 cmd.CommandText = "pkg_hd.P_GetOldParasEntityid";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.IID.cs
+++ b/AIS/AIS/DBConnection.IID.cs
@@ -18,7 +18,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_COMPLAINT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -50,7 +50,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.GET_COMPLAINTS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -70,7 +70,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.GET_COMPLAINTS_WITHOUT_ASSESSMENT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -97,7 +97,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.GET_COMPLAINT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -135,7 +135,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_ASSESSMENT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -160,7 +160,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_HEAD_REVIEW";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -192,7 +192,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_INV_PLAN";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -217,7 +217,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_PLAN_APPROVAL";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -243,7 +243,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_INQUIRY_REPORT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -275,7 +275,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_ANALYSIS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -303,7 +303,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_FINAL_APPROVAL";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -328,7 +328,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.ADD_CASE_STUDY";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -364,7 +364,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "PKG_INQ.GET_REPORTS";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.PG.cs
+++ b/AIS/AIS/DBConnection.PG.cs
@@ -18,7 +18,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditPeriodModel> periodList = new List<AuditPeriodModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GET_Auditperiod_status";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -46,7 +46,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditCCQModel> list = new List<AuditCCQModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetCCQ";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -106,7 +106,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditPeriodModel> periodList = new List<AuditPeriodModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetAuditPeriods";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -137,7 +137,7 @@ namespace AIS.Controllers
             {
             string resp = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_Update_AuditPeriod";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -161,7 +161,7 @@ namespace AIS.Controllers
             string resp = "";
             sessionHandler = new SessionHandler();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_AddAuditPeriod";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -190,7 +190,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             List<AuditTeamModel> teamList = new List<AuditTeamModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetAuditTeams";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -229,7 +229,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             string resp = "";
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_addauditteam";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -263,7 +263,7 @@ namespace AIS.Controllers
                 sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
                 var con = this.DatabaseConnection(); con.Open();
                 var loggedInUser = sessionHandler.GetSessionUser();
-                using (OracleCommand cmd = con.CreateCommand())
+                using (OracleCommand cmd = CreateSanitizedCommand(con))
                     {
                     cmd.CommandText = "pkg_pg.P_DeleteAuditTeam";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -289,7 +289,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             int maxTeamId = 1;
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_MAXTEAMID";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -320,7 +320,7 @@ namespace AIS.Controllers
             bool isAlreadyAdded = true;
 
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_ADDAUDITCRITERIA";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -359,7 +359,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_UpdateAuditCriteria";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -393,7 +393,7 @@ namespace AIS.Controllers
                 };
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_SetAuditCriteriaStatusReferredBack";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -419,7 +419,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             string REMARK = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_SetAuditCriteriaStatusApprove";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -450,7 +450,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditCriteriaModel> criteriaList = new List<AuditCriteriaModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetPendingAuditCriterias";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -499,7 +499,7 @@ namespace AIS.Controllers
 
             var con = this.DatabaseConnection(); con.Open();
             List<AuditCriteriaModel> criteriaList = new List<AuditCriteriaModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetRefferedBackAuditCriterias";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -545,7 +545,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditCriteriaModel> criteriaList = new List<AuditCriteriaModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetAuditCriteriasToAuthorize";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -592,7 +592,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditCriteriaModel> criteriaList = new List<AuditCriteriaModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_pg.P_GetPostChangesAuditCriterias";
@@ -647,7 +647,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.Tentative_Audit_Plan";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -678,7 +678,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             List<AuditEntitiesModel> entitiesList = new List<AuditEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetAuditEntities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -710,7 +710,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetAuditeeEntities";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -741,7 +741,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditEmployeeModel> empList = new List<AuditEmployeeModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetAuditEmployees";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -778,7 +778,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<TentativePlanModel> tplansList = new List<TentativePlanModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 string _sql = "pkg_pg.p_get_audit_plan";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -817,7 +817,7 @@ namespace AIS.Controllers
             {
             string result = "";
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetAuditOperationalStartDate";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -844,7 +844,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditRefEngagementPlanModel> list = new List<AuditRefEngagementPlanModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetAuditEngagementPlans";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -880,7 +880,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditRefEngagementPlanModel> list = new List<AuditRefEngagementPlanModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetRefferedBackAuditEngagementPlans";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -923,7 +923,7 @@ namespace AIS.Controllers
 
             ePlan.CREATEDBY = Convert.ToInt32(loggedInUser.PPNumber);
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_AddAuditEngagementPlan";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -985,7 +985,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_RefferedBackAuditEngagementPlan";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1009,7 +1009,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_RerecommendAuditEngagementPlan";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1043,7 +1043,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_ApproveAuditEngagementPlan";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1063,7 +1063,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             List<AuditFrequencyModel> freqList = new List<AuditFrequencyModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.p_GetAuditFrequencies";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1088,7 +1088,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             string response = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_pg.P_GetLatestCommentsOnEngagement";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.RPT.cs
+++ b/AIS/AIS/DBConnection.RPT.cs
@@ -16,7 +16,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditPeriodModel> periodList = new List<AuditPeriodModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GetAllParasYear";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -50,7 +50,7 @@ namespace AIS.Controllers
             else
                 entityId = div_code;
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_GetDepartments";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -108,7 +108,7 @@ namespace AIS.Controllers
 
             List<ZoneWiseOldParasPerformanceModel> list = new List<ZoneWiseOldParasPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GetZoneWiseOldParasPerformance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -136,7 +136,7 @@ namespace AIS.Controllers
             {
             var con = this.DatabaseConnection(); con.Open();
             ActiveInactiveChart chk = new ActiveInactiveChart();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GetActiveInactiveChartData";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -169,7 +169,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_Getchildposting";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -200,7 +200,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_Getparentrepoffice";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -235,7 +235,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 //AuditDepartmentList
                 cmd.CommandText = "pkg_rpt.P_AUDITED_BY_DEPARTMENTS";
@@ -269,7 +269,7 @@ namespace AIS.Controllers
             List<UserRelationshipModel> entitiesList = new List<UserRelationshipModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_Getrealtionshiptype";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -298,7 +298,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditPlanEngagementModel> periodList = new List<AuditPlanEngagementModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.r_audit_plan_engagement";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -348,7 +348,7 @@ namespace AIS.Controllers
             {
             List<JoiningCompletionReportModel> list = new List<JoiningCompletionReportModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_JOININGCOMPLETION";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -384,7 +384,7 @@ namespace AIS.Controllers
             {
             List<AuditPlanCompletionReportModel> list = new List<AuditPlanCompletionReportModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_AUDITPLANPROGRESS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -421,7 +421,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<CurrentAuditProgress> list = new List<CurrentAuditProgress>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_GetAuditees";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -450,7 +450,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<CurrentAuditProgress> list = new List<CurrentAuditProgress>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_GetAuditeesobervations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -482,7 +482,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<CurrentActiveUsers> list = new List<CurrentActiveUsers>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_LOGINUSERS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -516,7 +516,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ParaTextModel> list = new List<ParaTextModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.r_getauditeeParas";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -548,7 +548,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ZoneBranchParaStatusModel> list = new List<ZoneBranchParaStatusModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GetParaPositionForZoneBranches";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -580,7 +580,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditPlanReportModel> planList = new List<AuditPlanReportModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 string _sql = "pkg_rpt.r_eng_plan";
@@ -644,7 +644,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeAddressModel> list = new List<AuditeeAddressModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.r_getauditeeaddress";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -704,7 +704,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
 
             List<GetAuditeeParasModel> list = new List<GetAuditeeParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.r_getauditeeparas";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -737,7 +737,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GetTeamDetailsModel> list = new List<GetTeamDetailsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_getauditteams";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -772,7 +772,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GetFinalReportModel> list = new List<GetFinalReportModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.r_getauditeeparas";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -820,7 +820,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<AuditPlanReportModel> planList = new List<AuditPlanReportModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 string _sql = "pkg_rpt.r_eng_plan";
@@ -886,7 +886,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADGetReportEntititiesModel> list = new List<FADGetReportEntititiesModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_rpt.p_get_entities";
@@ -920,7 +920,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADGetReportZonesModel> list = new List<FADGetReportZonesModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = " pkg_rpt.p_get_az";
@@ -954,7 +954,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADEntitySizeModel> list = new List<FADEntitySizeModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_rpt.p_get_entity_size";
@@ -987,7 +987,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADEntityRiskModel> list = new List<FADEntityRiskModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
 
                 cmd.CommandText = "pkg_rpt.p_get_risk";
@@ -1019,7 +1019,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADNewParaPerformanceModel> list = new List<FADNewParaPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_new_paras_performance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1056,7 +1056,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADNewOldParaPerformanceModel> list = new List<FADNewOldParaPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_new_old_paras_performance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1094,7 +1094,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<FADLagacyParaPerformanceModel> list = new List<FADLagacyParaPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = " pkg_rpt.p_get_lagacy_paras_performance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1133,7 +1133,7 @@ namespace AIS.Controllers
 
             List<LegacyZoneWiseOldParasPerformanceModel> list = new List<LegacyZoneWiseOldParasPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GetZoneWiseOldParasPerformance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1167,7 +1167,7 @@ namespace AIS.Controllers
 
             List<LegacyUserWiseOldParasPerformanceModel> list = new List<LegacyUserWiseOldParasPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_Get_UserWise_OldParasPerformance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1202,7 +1202,7 @@ namespace AIS.Controllers
 
             List<FADHOUserLegacyParaUserWiseParasPerformanceModel> list = new List<FADHOUserLegacyParaUserWiseParasPerformanceModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_Get_FAD_UserWise_OldParasPerformance";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1237,7 +1237,7 @@ namespace AIS.Controllers
 
             List<ParaPositionReportModel> list = new List<ParaPositionReportModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_para_position";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1272,7 +1272,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ParaPositionDetailsModel> list = new List<ParaPositionDetailsModel>();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_para_position_details";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1304,7 +1304,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<FADNewOldParaPerformanceModel> pdetails = new List<FADNewOldParaPerformanceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_Dash_table_functionwise_HO";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1341,7 +1341,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RoleActivityLogModel> pdetails = new List<RoleActivityLogModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_ACTIVITY_LOG";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1374,7 +1374,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
             List<RoleActivityLogModel> pdetails = new List<RoleActivityLogModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_ACTIVITY_LOG";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1410,7 +1410,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<StatusWiseComplianceModel> respList = new List<StatusWiseComplianceModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_COMPLIANCE_STATUS_WISE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1460,7 +1460,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditParaReconsillation> resp = new List<AuditParaReconsillation>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_FAD_audit_Para_Reconciliation";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1508,7 +1508,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditPlanEngDetailReport> resp = new List<AuditPlanEngDetailReport>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_FAD_audit_Plan_Details";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1554,7 +1554,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AnnexureExerciseStatus> resp = new List<AnnexureExerciseStatus>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_FAD_ANNEXURE_REPORT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1588,7 +1588,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GroupWiseUsersCountModel> resp = new List<GroupWiseUsersCountModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_GROUP_WISE_USERS_COUNT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1620,7 +1620,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GroupWisePagesModel> resp = new List<GroupWisePagesModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_GROUP_WISE_PAGES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1652,7 +1652,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_ENTITY_TYPE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1685,7 +1685,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<DepttWiseOutstandingParasModel> resp = new List<DepttWiseOutstandingParasModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_DEPT_WISE_PARA_POSITION";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1723,7 +1723,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_loan_status";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1753,7 +1753,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_loan_gl";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1783,7 +1783,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_get_gm_list";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1813,7 +1813,7 @@ namespace AIS.Controllers
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
             var con = this.DatabaseConnection(); con.Open();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.R_get_rbh_list";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1844,7 +1844,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanDetailReportModel> resp = new List<LoanDetailReportModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_loan_to_default";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1890,7 +1890,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanDetailReportModel> resp = new List<LoanDetailReportModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_all_loans_of_cnic";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1932,7 +1932,7 @@ namespace AIS.Controllers
             var loggedInUser = sessionHandler.GetSessionUser();
             List<DefaultHisotryLoanDetailReportModel> resp = new List<DefaultHisotryLoanDetailReportModel>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_get_loan_to_default_history";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -1971,7 +1971,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<GISTWiseReportParas> resp = new List<GISTWiseReportParas>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_find_gist";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2007,7 +2007,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ComplianceProgressReportModel> resp = new List<ComplianceProgressReportModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_COM_PROGREE_REPORT ";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2044,7 +2044,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ComplianceProgressReportDetailModel> resp = new List<ComplianceProgressReportDetailModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_COM_PROGREE_REPORT_DETAIL ";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2086,7 +2086,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditEntitiesModel> entitiesList = new List<AuditEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_ENTITY_TYPE_FOR_SETTLEMENT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2118,7 +2118,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<SettledParasModel> resp = new List<SettledParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_COMPLIANCE_REPORT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2158,7 +2158,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ComplianceOSParasModel> resp = new List<ComplianceOSParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_PARA_POSITION_SUM";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2197,7 +2197,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<EngPlanDelayAnalysisReportModel> resp = new List<EngPlanDelayAnalysisReportModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.p_delay_audits";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2239,7 +2239,7 @@ namespace AIS.Controllers
                     {
                     con.Open();
 
-                    using (var cmd = con.CreateCommand())
+                    using (var cmd = CreateSanitizedCommand(con))
                         {
                         cmd.CommandText = "pkg_rpt.R_FAD_MONTHLY_REVIEW";
                         cmd.CommandType = CommandType.StoredProcedure;
@@ -2294,7 +2294,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<SeriousFraudulentObsGM> list = new List<SeriousFraudulentObsGM>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_GM_WISE_SERIOUS_PARAS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2337,7 +2337,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<SeriousFraudulentObsGMDetails> list = new List<SeriousFraudulentObsGMDetails>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_GM_WISE_SERIOUS_PARAS_DETAILS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2384,7 +2384,7 @@ namespace AIS.Controllers
             List<YearWiseOutstandingObservationsModel> responseList = new List<YearWiseOutstandingObservationsModel>();
             var loggedInUser = sessionHandler.GetSessionUser();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_YEAR_WISE_AUDIT_OUTSTANDING_PARAS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2425,7 +2425,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeOldParasModel> list = new List<AuditeeOldParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_YEAR_WISE_AUDIT_OUTSTANDING_PARAS_DETAILS";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2463,7 +2463,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ParaTextSearchModel> list = new List<ParaTextSearchModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_PARA_TEXT_WORDS_V2";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -2504,7 +2504,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<YearWiseAllParasModel> entitiesList = new List<YearWiseAllParasModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_rpt.P_GET_YEAR_WISE_ALL_PARAS";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.SM.cs
+++ b/AIS/AIS/DBConnection.SM.cs
@@ -18,7 +18,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_add_sample_data";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -56,7 +56,7 @@ namespace AIS.Controllers
             sessionHandler._session = this._session; sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection(); con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_add_exception_data";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -96,7 +96,7 @@ namespace AIS.Controllers
             List<BiometSamplingModel> responseList = new List<BiometSamplingModel>();
             var loggedInUser = sessionHandler.GetSessionUser();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.p_get_Account";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -150,7 +150,7 @@ namespace AIS.Controllers
             List<AccountTransactionSampleModel> responseList = new List<AccountTransactionSampleModel>();
             var loggedInUser = sessionHandler.GetSessionUser();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.p_get_account_transcations";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -202,7 +202,7 @@ namespace AIS.Controllers
             List<AccountDocumentBiometSamplingModel> responseList = new List<AccountDocumentBiometSamplingModel>();
             var loggedInUser = sessionHandler.GetSessionUser();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_GET_ACCOUNT_DOC ";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -241,7 +241,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ListOfSamplesModel> list = new List<ListOfSamplesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_GET_SAMPLE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -278,7 +278,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanCaseSampleModel> list = new List<LoanCaseSampleModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_GET_LOANS_SAMPLE";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -322,7 +322,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanCaseSampleModel> list = new List<LoanCaseSampleModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_GET_LOANS_Exceptions";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -365,7 +365,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanCaseSampleDocumentsModel> list = new List<LoanCaseSampleDocumentsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.p_get_Loan_Documents";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -406,7 +406,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanCaseSampleDocumentsModel> list = new List<LoanCaseSampleDocumentsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.p_get_Loan_Documents_image";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -447,7 +447,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<LoanCaseSampleTransactionsModel> list = new List<LoanCaseSampleTransactionsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.p_get_Loan_Transactions";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -498,7 +498,7 @@ namespace AIS.Controllers
             sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<AuditeeEntitiesModel> entitiesList = new List<AuditeeEntitiesModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_GET_SAMPLE_ENTITIES";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -532,7 +532,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             string resp = "";
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_add_sample_data_update";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -563,7 +563,7 @@ namespace AIS.Controllers
             sessionHandler._configuration = this._configuration;
             var loggedInUser = sessionHandler.GetSessionUser();
             List<CDMSMasterTransactionModel> list = new List<CDMSMasterTransactionModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.p_get_account_transcations_master";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -619,7 +619,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
             List<ListOfReportsModel> list = new List<ListOfReportsModel>();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.T_AU_EXCEPTION_REPORT";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -656,7 +656,7 @@ namespace AIS.Controllers
             sessionHandler._configuration = this._configuration;
             var con = this.DatabaseConnection(); con.Open();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.P_Add_new_exp_report";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -691,7 +691,7 @@ namespace AIS.Controllers
             con.Open();
             List<AccountExceptionsModel> responseList = new List<AccountExceptionsModel>();
             var loggedInUser = sessionHandler.GetSessionUser();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                 cmd.CommandText = "pkg_sm.p_exception_get_Account";
                 cmd.CommandType = CommandType.StoredProcedure;

--- a/AIS/AIS/DBConnection.cs
+++ b/AIS/AIS/DBConnection.cs
@@ -9,8 +9,10 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace AIS.Controllers
 {
@@ -67,6 +69,55 @@ namespace AIS.Controllers
         }
         #endregion
 
+        private SanitizedOracleCommand CreateSanitizedCommand(OracleConnection connection)
+        {
+            return new SanitizedOracleCommand(connection, SanitizeVarcharParameters);
+        }
+
+        private void SanitizeVarcharParameters(OracleCommand command)
+        {
+            foreach (OracleParameter parameter in command.Parameters)
+            {
+                if (parameter.OracleDbType != OracleDbType.Varchar2 || parameter.Value == null)
+                    continue;
+
+                if (parameter.Value is not string textValue)
+                    continue;
+
+                parameter.Value = IsRichTextParameter(parameter.ParameterName)
+                    ? SanitizeRichText(textValue)
+                    : SanitizePlainText(textValue);
+            }
+        }
+
+        private static bool IsRichTextParameter(string? parameterName)
+        {
+            if (string.IsNullOrWhiteSpace(parameterName))
+                return false;
+
+            string[] richTextKeys = new[] { "OBSERVATION", "RESPONSE", "ANNEXURE", "BODY", "COMMENT", "PARAGRAPH" };
+            return richTextKeys.Any(key => parameterName.Contains(key, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string SanitizePlainText(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return string.Empty;
+
+            string withoutHtml = Regex.Replace(value, "<[^>]+>", string.Empty, RegexOptions.Multiline);
+            string trimmed = Regex.Replace(withoutHtml, "[\\r\\n]+", " ").Trim();
+            return trimmed.TrimStart('=', '+', '-', '@');
+        }
+
+        private static string SanitizeRichText(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return string.Empty;
+
+            string withoutScripts = Regex.Replace(value, "<script[^>]*?>.*?</script>", string.Empty, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            return withoutScripts;
+        }
+
         private string DecryptPassword(string encryptedPassword)
         {
             byte[] bytes = Convert.FromBase64String(encryptedPassword);
@@ -95,7 +146,7 @@ namespace AIS.Controllers
             var sessionUser = sessionHandler.GetSessionUser();
             var con = this.DatabaseConnection();
             con.Open();
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
             {
                 cmd.CommandText = "pkg_lg.Session_END";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -127,7 +178,7 @@ namespace AIS.Controllers
             {
                 var con = this.DatabaseConnection();
                 con.Open();
-                using (OracleCommand cmd = con.CreateCommand())
+                using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                     cmd.CommandText = "pkg_lg.p_get_user_session";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -156,7 +207,7 @@ namespace AIS.Controllers
             var con = this.DatabaseConnection();
             con.Open();
             bool isSession = false;
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
             {
                 string _sql = "pkg_lg.p_get_user";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -193,7 +244,7 @@ namespace AIS.Controllers
             {
                 var con = this.DatabaseConnection();
                 con.Open();
-                using (OracleCommand cmd = con.CreateCommand())
+                using (OracleCommand cmd = CreateSanitizedCommand(con))
                 {
                     cmd.CommandText = "pkg_lg.Session_Kill";
                     cmd.CommandType = CommandType.StoredProcedure;
@@ -236,7 +287,7 @@ namespace AIS.Controllers
 
             List<object> list = new List<object>();
 
-            using (OracleCommand cmd = con.CreateCommand())
+            using (OracleCommand cmd = CreateSanitizedCommand(con))
             {
                 cmd.CommandText = "pkg_ae.P_GetObservationText";
                 cmd.CommandType = CommandType.StoredProcedure;
@@ -299,5 +350,40 @@ namespace AIS.Controllers
             return list;
         }
         #endregion
+
+        private class SanitizedOracleCommand : OracleCommand
+        {
+            private readonly Action<OracleCommand> _sanitize;
+
+            public SanitizedOracleCommand(OracleConnection connection, Action<OracleCommand> sanitize)
+            {
+                Connection = connection;
+                _sanitize = sanitize;
+            }
+
+            public override OracleDataReader ExecuteReader()
+            {
+                _sanitize(this);
+                return base.ExecuteReader();
+            }
+
+            public override OracleDataReader ExecuteReader(CommandBehavior behavior)
+            {
+                _sanitize(this);
+                return base.ExecuteReader(behavior);
+            }
+
+            public override int ExecuteNonQuery()
+            {
+                _sanitize(this);
+                return base.ExecuteNonQuery();
+            }
+
+            public override object ExecuteScalar()
+            {
+                _sanitize(this);
+                return base.ExecuteScalar();
+            }
+        }
     }
 }

--- a/AIS/AIS/wwwroot/js/site.js
+++ b/AIS/AIS/wwwroot/js/site.js
@@ -238,6 +238,57 @@ function initializeDataTableWithoutExport(id) {
     return dTable;
 }
 
+function isRichTextField(element) {
+    const $el = $(element);
+    const id = ($el.attr('id') || '').toLowerCase();
+    const name = ($el.attr('name') || '').toLowerCase();
+    const classes = ($el.attr('class') || '').toLowerCase();
+    const allowHtml = $el.data('allow-html') === true;
+    const richKeywords = ['observation', 'response', 'annexure', 'body', 'comment', 'paragraph'];
+
+    if (allowHtml || classes.indexOf('richtext') >= 0 || classes.indexOf('rich-text') >= 0 || classes.indexOf('richtext-editor') >= 0) {
+        return true;
+    }
+
+    return richKeywords.some(key => id.indexOf(key) >= 0 || name.indexOf(key) >= 0);
+}
+
+function sanitizePlainTextInput(value) {
+    if (!value) {
+        return '';
+    }
+
+    let sanitized = value.replace(/<[^>]+>/g, '');
+    sanitized = sanitized.replace(/[\r\n]+/g, ' ').trim();
+    sanitized = sanitized.replace(/^[=+\-@]+/, '');
+    return sanitized;
+}
+
+function attachPlainTextValidation() {
+    $('input[type="text"], textarea').each(function () {
+        if (isRichTextField(this)) {
+            return;
+        }
+
+        const $field = $(this);
+        $field.addClass('plaintext-validated');
+        if (!$field.attr('placeholder')) {
+            $field.attr('placeholder', 'Plain text only – no HTML or formulas');
+        }
+
+        $field.on('input blur', function () {
+            const sanitized = sanitizePlainTextInput($field.val());
+            if ($field.val() !== sanitized) {
+                $field.val(sanitized);
+            }
+        });
+    });
+}
+
+$(document).ready(function () {
+    attachPlainTextValidation();
+});
+
 
 
 


### PR DESCRIPTION
## Summary
- add centralized sanitization for Oracle VARCHAR2 parameters via sanitized command wrapper
- ensure default plain-text validation applies to text inputs while skipping rich text fields

## Testing
- dotnet build AIS.sln *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e8de75864832eb2f6e4317623fbf7)