### PR TITLE
Allow HTTP usage and centralize configuration in appsettings

### DIFF
--- a/AIS/AIS/Controllers/ApiCallsController.cs
+++ b/AIS/AIS/Controllers/ApiCallsController.cs
@@ -2,6 +2,7 @@
 using AIS.Models.AIS.Models;
 using AIS.Models.IID;
 using AIS;
+using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -24,13 +25,15 @@ namespace AIS.Controllers
         private readonly SessionHandler sessionHandler;
         private readonly dynamic dBConnection;
         private readonly IWebHostEnvironment _hostingEnvironment;
+        private readonly IConfiguration _configuration;
 
-        public ApiCallsController(ILogger<ApiCallsController> logger, SessionHandler _sessionHandler, DBConnection _dbCon, IWebHostEnvironment hostingEnvironment)
+        public ApiCallsController(ILogger<ApiCallsController> logger, SessionHandler _sessionHandler, DBConnection _dbCon, IWebHostEnvironment hostingEnvironment, IConfiguration configuration)
             {
             _logger = logger;
             sessionHandler = _sessionHandler;
             dBConnection = _dbCon;
             _hostingEnvironment = hostingEnvironment;
+            _configuration = configuration;
             }
 
         [HttpPost]
@@ -3214,7 +3217,7 @@ namespace AIS.Controllers
             };
             if(emailMap.ContainsKey(model.AssignedToUnit))
                 {
-                EmailConfiguration email = new EmailConfiguration();
+                EmailConfiguration email = new EmailConfiguration(_configuration);
                 string body = $"Complaint {model.ComplaintId} assigned to your unit.";
                 email.ConfigEmail(emailMap[model.AssignedToUnit], "", "IAS Assignment", body);
                 }

--- a/AIS/AIS/Controllers/EmailController.cs
+++ b/AIS/AIS/Controllers/EmailController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using System.IO;
 using System.Threading;
 
@@ -9,11 +10,12 @@ namespace AIS.Controllers
     {
         private readonly IWebHostEnvironment _env;
         private static Timer _reminderTimer;
-        private readonly EmailConfiguration _emailConfig = new EmailConfiguration();
+        private readonly EmailConfiguration _emailConfig;
 
-        public EmailController(IWebHostEnvironment env)
+        public EmailController(IWebHostEnvironment env, IConfiguration configuration)
             {
             _env = env;
+            _emailConfig = new EmailConfiguration(configuration);
             }
 
         public IActionResult Edit()

--- a/AIS/AIS/Controllers/LoginController.cs
+++ b/AIS/AIS/Controllers/LoginController.cs
@@ -28,8 +28,8 @@ namespace AIS.Controllers
             {
             TempData["Message"] = "";
             TempData["SessionKill"] = "";
-            string secretValue = _configuration["SecretKey"];
-            string baseURL = _configuration["BaseURL"];
+            string secretValue = _configuration["Security:SecretKey"];
+            string baseURL = _configuration["Security:BaseURL"];
             string dbDataSource = _configuration["ConnectionStrings:DBDataSource"];
             ViewBag.SecretValue = secretValue;
             ViewBag.BaseURL = baseURL;

--- a/AIS/AIS/DBConnection.cs
+++ b/AIS/AIS/DBConnection.cs
@@ -26,7 +26,7 @@ namespace AIS.Controllers
         public ISession _session;
         public IHttpContextAccessor _httpCon;
         public IConfiguration _configuration;
-        private readonly string CAU_KEY = "112233";
+        private string CAU_KEY => _configuration?["Security:CAUKey"] ?? string.Empty;
 
         [Obsolete]
         private readonly IHostingEnvironment _env;

--- a/AIS/AIS/EmailConfiguration.cs
+++ b/AIS/AIS/EmailConfiguration.cs
@@ -1,5 +1,6 @@
-﻿using AIS;
+using AIS;
 using AIS.Models;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Net;
 using System.Net.Mail;
@@ -7,7 +8,12 @@ using System.Threading.Tasks;
 
 public class EmailConfiguration
     {
-    private readonly EmailCredentails emailCredentails = new EmailCredentails();
+    private readonly EmailCredentails emailCredentails;
+
+    public EmailConfiguration(IConfiguration? configuration = null)
+        {
+        emailCredentails = new EmailCredentails(configuration);
+        }
 
     public bool ConfigEmail(string to = "", string cc = "", string subj = "", string body = "")
         {

--- a/AIS/AIS/EmailCredentials.cs
+++ b/AIS/AIS/EmailCredentials.cs
@@ -1,17 +1,31 @@
-﻿using AIS.Models;
+using AIS.Models;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.IO;
 
 namespace AIS
     {
 
     public class EmailCredentails
         {
+        private readonly IConfiguration _configuration;
+
+        public EmailCredentails(IConfiguration? configuration = null)
+            {
+            _configuration = configuration ?? new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true, reloadOnChange: true)
+                .Build();
+            }
+
         public EmailCredentailsModel GetEmailCredentails()
             {
             EmailCredentailsModel em = new EmailCredentailsModel();
-            em.EMAIL = "noreply.audit@ztbl.com.pk";
-            em.PASSWORD = "Hello@321";
-            em.Host = "webmail.ztbl.com.pk";
-            em.Port = 587;
+            em.EMAIL = _configuration["Email:address"] ?? string.Empty;
+            em.PASSWORD = _configuration["Email:PASSWORD"] ?? string.Empty;
+            em.Host = _configuration["Email:Host"] ?? string.Empty;
+            em.Port = int.TryParse(_configuration["Email:Port"], out int port) ? port : 0;
             return em;
 
             }

--- a/AIS/AIS/Startup.cs
+++ b/AIS/AIS/Startup.cs
@@ -54,7 +54,7 @@ namespace AIS
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
             {
-            var baseUrl = Configuration["BaseURL"];
+            var baseUrl = Configuration["Security:BaseURL"];
             if (!string.IsNullOrEmpty(baseUrl))
                 {
                 app.UsePathBase(baseUrl);
@@ -66,9 +66,7 @@ namespace AIS
             else
                 {
                 app.UseExceptionHandler("/Home/Error");
-                app.UseHsts();
                 }
-            app.UseHttpsRedirection();
 
             // Disable client-side caching to mimic a hard refresh on every load
             app.Use(async (context, next) =>

--- a/AIS/AIS/Views/Shared/_BlankLayout.cshtml
+++ b/AIS/AIS/Views/Shared/_BlankLayout.cshtml
@@ -8,7 +8,7 @@
     <title>@ViewData["Title"] - IAS</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
-    <meta name="base-url" content="@Configuration["BaseURL"]" />
+    <meta name="base-url" content="@Configuration["Security:BaseURL"]" />
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     
 </head>

--- a/AIS/AIS/Views/Shared/_Layout.cshtml
+++ b/AIS/AIS/Views/Shared/_Layout.cshtml
@@ -5,7 +5,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="base-url" content="@Configuration["BaseURL"]" />
+    <meta name="base-url" content="@Configuration["Security:BaseURL"]" />
     <title>@ViewData["Title"] - IAS</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />

--- a/AIS/AIS/appsettings.json
+++ b/AIS/AIS/appsettings.json
@@ -9,11 +9,23 @@
   "ConnectionStrings": {
     "DBUserName": "ZTBLAIS_PROD",
     "DBUserPassword": "ZTBLAIS_PROD",
-    //"DBDataSource": "10.100.102.130:1521/dimisdb2.l1.local"
     "DBDataSource": "10.1.100.111:1521/l0devdb1.ztbl.com.pk"
   },
-  "AllowedHosts": "*",
-  "SecretKey": "VzZDSrxQ0JfXk1bC/xfptlYg6MWESBuRYc2iNGjaP0o=",
-  "BaseURL": "/ZTBLAIS"
-  //"BaseURL": ""
+  "Security": {
+    "AllowedHosts": "*",
+    "SecretKey": "VzZDSrxQ0JfXk1bC/xfptlYg6MWESBuRYc2iNGjaP0o=",
+    "CAUKey": "112233",
+    "BaseURL": "/ZTBLAIS"
+  },
+  "PasswordPolicy": {
+    "MinimumLength": 8,
+    "BlocklistPath": "Security/PasswordPolicy/password_blocklist.txt",
+    "RejectIdentifiers": true
+  },
+  "Email": {
+    "address": "noreply.audit@ztbl.com.pk",
+    "PASSWORD": "Hello@321",
+    "Host": "webmail.ztbl.com.pk",
+    "Port": 587
+  }
 }


### PR DESCRIPTION
## Summary
- enable BaseURL and security values to come from appsettings.json and update views/controllers accordingly
- load email configuration from appsettings.json and pass IConfiguration into email workflows
- remove forced HTTPS redirection to allow HTTP publishing and keep appsettings as the central configuration source

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694292b8a784832eacf1b201bfb7bd7b)